### PR TITLE
Fix CVL client bean

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/WebClientConfiguration.kt
@@ -99,17 +99,7 @@ class WebClientConfiguration(
   }
 
   @Bean
-  fun cvlWebClient(): WebClient {
-    val httpClient = HttpClient.create().responseTimeout(Duration.ofMinutes(2))
-    return WebClient.builder()
-      .baseUrl(cvlRootUri)
-      .clientConnector(ReactorClientHttpConnector(httpClient))
-      .filter(AuthTokenFilterFunction())
-      .build()
-  }
-
-  @Bean
-  fun cvlWebClientCredentials(authorizedClientManager: ReactiveOAuth2AuthorizedClientManager): WebClient {
+  fun cvlWebClientClientCredentials(authorizedClientManager: ReactiveOAuth2AuthorizedClientManager): WebClient {
     val oauth2Client = ServerOAuth2AuthorizedClientExchangeFilterFunction(authorizedClientManager)
     oauth2Client.setDefaultClientRegistrationId(SYSTEM_USERNAME)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/LicenceConditionApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/LicenceConditionApiService.kt
@@ -19,11 +19,11 @@ import java.time.format.DateTimeFormatter
 
 @Service
 class LicenceConditionApiService(
-  private val cvlWebClient: WebClient,
+  private val cvlWebClientClientCredentials: WebClient,
 ) {
 
   suspend fun findLicencesByNomisId(nomisId: List<String>): Flow<LicenceSummary> =
-    cvlWebClient.post()
+    cvlWebClientClientCredentials.post()
       .uri("/licence/match")
       .bodyValue(
         LicenceRequest(
@@ -67,7 +67,7 @@ class LicenceConditionApiService(
   }
 
   suspend fun fetchLicenceConditionsByLicenceId(licenceId: Long): Licence =
-    cvlWebClient.get()
+    cvlWebClientClientCredentials.get()
       .uri(
         "/licence/id/{licenceId}",
         mapOf(
@@ -120,7 +120,7 @@ class LicenceConditionApiService(
   }
 
   fun getImageFromLicenceIdAndConditionId(licenceId: String, conditionId: String): Flow<ByteArray> = flow {
-    val image = cvlWebClient
+    val image = cvlWebClientClientCredentials
       .get()
       .uri(
         "/exclusion-zone/id/$licenceId/condition/id/$conditionId/full-size-image",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/HmppsAuthMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/HmppsAuthMockServer.kt
@@ -15,7 +15,7 @@ class HmppsAuthMockServer : WireMockServer(WIREMOCK_PORT) {
 
   fun stubGrantToken() {
     stubFor(
-      post(urlEqualTo("/auth/oauth/token"))
+      post(urlEqualTo("/oauth/token"))
         .willReturn(
           aResponse()
             .withHeaders(HttpHeaders(HttpHeader("Content-Type", "application/json")))


### PR DESCRIPTION
We need to use the Client version of the WebClient bean so it uses the system account to connect to the downstream CVL system. I've deleted the other one (that uses the original user auth) to avoid confusion as we don't need it.