### PR TITLE
FIX: make cellLocation optional for prisonerSearch results

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/prisonersapi/PrisonersSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/prisonersapi/PrisonersSearch.kt
@@ -13,7 +13,7 @@ data class PrisonersSearch(
   val youthOffender: Boolean?,
   val prisonId: String,
   val prisonName: String,
-  val cellLocation: String,
+  val cellLocation: String?,
 )
 
 data class PrisonerRequest(


### PR DESCRIPTION
small fix to allow prisoner search results which do not contain a cell location