### PR TITLE
PSFR-1319 Persist assessment skip form

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/AuditConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/AuditConfig.kt
@@ -17,7 +17,6 @@ class AuditConfig {
 private class UsernameAuditorAware() : AuditorAware<String> {
   override fun getCurrentAuditor(): Optional<String> {
     val username = SecurityContextHolder.getContext()?.authentication?.name
-    println("YOOO $username")
     return Optional.ofNullable(username)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/AuditConfig.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/AuditConfig.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.domain.AuditorAware
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.security.core.context.SecurityContextHolder
+import java.util.Optional
+
+@Configuration
+@EnableJpaAuditing(auditorAwareRef = "auditorAware")
+class AuditConfig {
+  @Bean
+  fun auditorAware(): AuditorAware<String> = UsernameAuditorAware()
+}
+
+private class UsernameAuditorAware() : AuditorAware<String> {
+  override fun getCurrentAuditor(): Optional<String> {
+    val username = SecurityContextHolder.getContext()?.authentication?.name
+    println("YOOO $username")
+    return Optional.ofNullable(username)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilter.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config
 
+import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 import org.springframework.web.server.ServerWebExchange
@@ -7,12 +8,13 @@ import org.springframework.web.server.WebFilter
 import org.springframework.web.server.WebFilterChain
 import reactor.core.publisher.Mono
 
-@Component
-class LoggingWebFilter : WebFilter {
+private val logInstance = LoggerFactory.getLogger(LoggingWebFilter::class.java)
 
-  companion object {
-    private val log = LoggerFactory.getLogger(this::class.java)
-  }
+@Component
+class LoggingWebFilter(
+  val log: Logger,
+) : WebFilter {
+  constructor() : this(logInstance)
 
   override fun filter(exchange: ServerWebExchange, chain: WebFilterChain): Mono<Void> {
     if (log.isDebugEnabled) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/Prisoners.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/Prisoners.kt
@@ -62,4 +62,6 @@ data class Prisoner(
   var pathways: List<PathwayStatus>? = ArrayList(),
   val assessmentRequired: Boolean,
   val resettlementReviewAvailable: Boolean,
+  val immediateNeedsSubmitted: Boolean,
+  val preReleaseSubmitted: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/ResettlementAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/ResettlementAssessment.kt
@@ -63,8 +63,8 @@ data class LatestResettlementAssessmentResponseQuestionAndAnswer(
 )
 
 data class AssessmentSkipRequest(
-  val assessmentSkipReason: AssessmentSkipReason,
-  val moreInformation: String? = null,
+  val reason: AssessmentSkipReason,
+  val moreInfo: String? = null,
 )
 
 enum class AssessmentSkipReason {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/ResettlementAssessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/ResettlementAssessment.kt
@@ -61,3 +61,16 @@ data class LatestResettlementAssessmentResponseQuestionAndAnswer(
   val answer: String?,
   val originalPageId: String,
 )
+
+data class AssessmentSkipRequest(
+  val assessmentSkipReason: AssessmentSkipReason,
+  val moreInformation: String? = null,
+)
+
+enum class AssessmentSkipReason {
+  COMPLETED_IN_OASYS,
+  COMPLETED_IN_ANOTHER_PRISON,
+  EARLY_RELEASE,
+  TRANSFER,
+  OTHER,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/AssessmentSkipEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/AssessmentSkipEntity.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity
 
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -21,6 +23,7 @@ data class AssessmentSkipEntity(
   val id: Long? = null,
   val assessmentType: ResettlementAssessmentType,
   val prisonerId: Long,
+  @Enumerated(EnumType.STRING)
   val reason: AssessmentSkipReason,
   val moreInfo: String? = null,
   @CreatedBy

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/AssessmentSkipEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/AssessmentSkipEntity.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.springframework.data.annotation.CreatedBy
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.AssessmentSkipReason
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "assessment_skip")
+@EntityListeners(AuditingEntityListener::class)
+data class AssessmentSkipEntity(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val id: Long? = null,
+  val assessmentType: ResettlementAssessmentType,
+  val prisonerId: Long,
+  val reason: AssessmentSkipReason,
+  val moreInfo: String? = null,
+  @CreatedBy
+  var createdBy: String? = null,
+  @CreatedDate
+  var creationDate: LocalDateTime? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepository.kt
@@ -1,0 +1,6 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
+
+interface AssessmentSkipRepository : JpaRepository<AssessmentSkipEntity, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ResettlementAssessmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ResettlementAssessmentRepository.kt
@@ -9,6 +9,19 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
 
 interface ResettlementAssessmentRepository : JpaRepository<ResettlementAssessmentEntity, Long> {
+
+  @Query(
+    """
+      select * from (
+        select *, rank() over (partition by pathway order by created_date desc) as rank from resettlement_assessment
+        where assessment_type = :#{#assessmentType.toString()}
+        and prisoner_id = :#{#prisoner.id}
+      ) by_pathway where rank = 1;
+    """,
+    nativeQuery = true,
+  )
+  fun findLatestForEachPathway(prisoner: PrisonerEntity, assessmentType: ResettlementAssessmentType): List<ResettlementAssessmentEntity>
+
   fun findFirstByPrisonerAndPathwayAndAssessmentTypeOrderByCreationDateDesc(prisoner: PrisonerEntity, pathway: Pathway, assessmentType: ResettlementAssessmentType): ResettlementAssessmentEntity?
 
   fun findFirstByPrisonerAndPathwayAndAssessmentStatusOrderByCreationDateDesc(prisoner: PrisonerEntity, pathway: Pathway, assessmentStatus: ResettlementAssessmentStatus): ResettlementAssessmentEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ResettlementAssessmentRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ResettlementAssessmentRepository.kt
@@ -22,6 +22,17 @@ interface ResettlementAssessmentRepository : JpaRepository<ResettlementAssessmen
   )
   fun findLatestForEachPathway(prisoner: PrisonerEntity, assessmentType: ResettlementAssessmentType): List<ResettlementAssessmentEntity>
 
+  @Query(
+    """
+      select * from (
+        select *, rank() over (partition by pathway order by created_date desc) as rank from resettlement_assessment
+        where prisoner_id = :#{#prisoner.id}
+      ) by_pathway where rank = 1;
+    """,
+    nativeQuery = true,
+  )
+  fun findLatestForEachPathwayAndType(prisoner: PrisonerEntity): List<ResettlementAssessmentEntity>
+
   fun findFirstByPrisonerAndPathwayAndAssessmentTypeOrderByCreationDateDesc(prisoner: PrisonerEntity, pathway: Pathway, assessmentType: ResettlementAssessmentType): ResettlementAssessmentEntity?
 
   fun findFirstByPrisonerAndPathwayAndAssessmentStatusOrderByCreationDateDesc(prisoner: PrisonerEntity, pathway: Pathway, assessmentStatus: ResettlementAssessmentStatus): ResettlementAssessmentEntity?

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.AssessmentSkipRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.ResettlementAssessmentCompleteRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.ResettlementAssessmentNextPage
@@ -313,4 +314,47 @@ class ResettlementAssessmentController(
     @Parameter(required = true)
     pathway: Pathway,
   ) = resettlementAssessmentService.getLatestResettlementAssessmentByNomsIdAndPathway(nomsId, pathway, resettlementAssessmentStrategies)
+
+  @PostMapping("/{nomsId}/resettlement-assessment/skip", produces = [MediaType.APPLICATION_JSON_VALUE])
+  @Operation(summary = "Skip an assessment")
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Successful Operation",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = MediaType.APPLICATION_JSON_VALUE,
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Incorrect information provided",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun postSkipAssessmentByNomsId(
+    @Schema(example = "AXXXS", required = true)
+    @PathVariable("nomsId")
+    nomsId: String,
+    @RequestParam("assessmentType", defaultValue = "BCST2", required = false)
+    assessmentType: ResettlementAssessmentType,
+    @RequestBody
+    request: AssessmentSkipRequest,
+  ): ResponseEntity<Void> {
+    resettlementAssessmentService.skipAssessment(nomsId, assessmentType, request)
+    return ResponseEntity.noContent().build()
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
@@ -228,8 +228,8 @@ class ResettlementAssessmentService(
       AssessmentSkipEntity(
         prisonerId = prisonerEntity.id!!,
         assessmentType = assessmentType,
-        reason = request.assessmentSkipReason,
-        moreInfo = request.moreInformation,
+        reason = request.reason,
+        moreInfo = request.moreInfo,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ServerWebInputException
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ResourceNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.AssessmentSkipRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.LatestResettlementAssessmentResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.LatestResettlementAssessmentResponseQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
@@ -17,8 +18,11 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettleme
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.Option
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.PrisonerResettlementAssessment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.AssessmentSkipRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.ResettlementAssessmentRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies.GenericResettlementAssessmentQuestion
@@ -31,19 +35,23 @@ class ResettlementAssessmentService(
   private val prisonerRepository: PrisonerRepository,
   private val caseNotesService: CaseNotesService,
   private val pathwayAndStatusService: PathwayAndStatusService,
+  private val assessmentSkipRepository: AssessmentSkipRepository,
 ) {
   @Transactional
   fun getResettlementAssessmentSummaryByNomsId(nomsId: String, assessmentType: ResettlementAssessmentType): List<PrisonerResettlementAssessment> {
-    val prisonerEntity = prisonerRepository.findByNomsId(nomsId)
-      ?: throw ResourceNotFoundException("Prisoner with id $nomsId not found in database")
-    val pathways = Pathway.entries.toTypedArray()
-    return pathways.map {
-      val resettlementAssessmentForPathway =
-        resettlementAssessmentRepository.findFirstByPrisonerAndPathwayAndAssessmentTypeOrderByCreationDateDesc(
-          prisonerEntity,
-          it,
-          assessmentType,
-        )
+    val prisonerEntity = getPrisonerEntityOrThrow(nomsId)
+    return getAssessmentSummary(prisonerEntity, assessmentType)
+  }
+
+  private fun getAssessmentSummary(
+    prisonerEntity: PrisonerEntity,
+    assessmentType: ResettlementAssessmentType,
+  ): List<PrisonerResettlementAssessment> {
+    val latestForEachPathway =
+      resettlementAssessmentRepository.findLatestForEachPathway(prisonerEntity, assessmentType)
+        .associateBy { it.pathway }
+    return Pathway.entries.map {
+      val resettlementAssessmentForPathway = latestForEachPathway[it]
       if (resettlementAssessmentForPathway == null) {
         PrisonerResettlementAssessment(it, ResettlementAssessmentStatus.NOT_STARTED)
       } else {
@@ -54,6 +62,11 @@ class ResettlementAssessmentService(
       }
     }
   }
+
+  private fun getPrisonerEntityOrThrow(nomsId: String) = (
+    prisonerRepository.findByNomsId(nomsId)
+      ?: throw ResourceNotFoundException("Prisoner with id $nomsId not found in database")
+    )
 
   @Transactional
   fun submitResettlementAssessmentByNomsId(nomsId: String, assessmentType: ResettlementAssessmentType, auth: String) {
@@ -198,4 +211,26 @@ class ResettlementAssessmentService(
       .map { it.trim() }
       .map { element -> options?.find { it.id == element }?.displayText ?: element }
       .reduceOrNull { acc, value -> "$acc\n$value" } ?: ""
+
+  @Transactional
+  fun skipAssessment(nomsId: String, assessmentType: ResettlementAssessmentType, request: AssessmentSkipRequest) {
+    if (assessmentType != ResettlementAssessmentType.BCST2) {
+      throw ServerWebInputException("Only BCST2 assessment can currently be skipped")
+    }
+
+    val prisonerEntity = getPrisonerEntityOrThrow(nomsId)
+    val assessmentSummary = getAssessmentSummary(prisonerEntity, assessmentType)
+    if (assessmentSummary.any { it.assessmentStatus != ResettlementAssessmentStatus.NOT_STARTED }) {
+      throw ServerWebInputException("Cannot skip assessment that has already been started")
+    }
+
+    assessmentSkipRepository.save(
+      AssessmentSkipEntity(
+        prisonerId = prisonerEntity.id!!,
+        assessmentType = assessmentType,
+        reason = request.assessmentSkipReason,
+        moreInfo = request.moreInformation,
+      ),
+    )
+  }
 }

--- a/src/main/resources/db/migration/V1_43__add_assessment_skip.sql
+++ b/src/main/resources/db/migration/V1_43__add_assessment_skip.sql
@@ -1,0 +1,12 @@
+CREATE TABLE assessment_skip
+(
+    id              serial primary key,
+    prisoner_id     integer                  not null references prisoner (id),
+    assessment_type varchar(50),
+
+    reason          varchar(50),
+    more_info       text,
+
+    created_by      varchar(100)             not null,
+    creation_date   timestamp with time zone not null default now()
+);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilterTest.kt
@@ -1,20 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config
 
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
-import org.mockito.MockedStatic
 import org.mockito.Mockito.any
-import org.mockito.Mockito.anyString
-import org.mockito.Mockito.mockStatic
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.`when`
 import org.mockito.junit.jupiter.MockitoExtension
 import org.slf4j.Logger
-import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest
 import org.springframework.mock.web.server.MockServerWebExchange
@@ -30,24 +24,9 @@ class LoggingWebFilterTest {
   @Mock
   private lateinit var mockLogger: Logger
 
-  private lateinit var mockLoggerFactory: MockedStatic<LoggerFactory>
-
-  @BeforeEach
-  fun setup() {
-    mockLoggerFactory = mockStatic(LoggerFactory::class.java)
-    `when`(LoggerFactory.getLogger(any(Class::class.java))).thenReturn(mockLogger)
-    `when`(LoggerFactory.getLogger(anyString())).thenReturn(mockLogger)
-    `when`(mockLogger.name).thenReturn("mockLogger")
-  }
-
-  @AfterEach
-  fun reset() {
-    mockLoggerFactory.close()
-  }
-
   @Test
   fun `Should filter without SessionID`() {
-    val filter = LoggingWebFilter()
+    val filter = LoggingWebFilter(mockLogger)
     val exchange = createMockExchange()
     `when`(webFilterChain.filter(exchange)).thenReturn(Mono.empty())
     filter.filter(exchange, webFilterChain).block()
@@ -57,7 +36,7 @@ class LoggingWebFilterTest {
 
   @Test
   fun `Should filter with SessionID`() {
-    val filter = LoggingWebFilter()
+    val filter = LoggingWebFilter(mockLogger)
     val exchange = createMockExchangeWithSessionID("testSessionID")
     `when`(webFilterChain.filter(exchange)).thenReturn(Mono.empty())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilterTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/LoggingWebFilterTest.kt
@@ -50,7 +50,7 @@ class LoggingWebFilterTest {
     val filter = LoggingWebFilter()
     val exchange = createMockExchange()
     `when`(webFilterChain.filter(exchange)).thenReturn(Mono.empty())
-    filter.filter(exchange, webFilterChain)
+    filter.filter(exchange, webFilterChain).block()
     verify(webFilterChain).filter(exchange)
     verify(mockLogger, times(0)).info(any())
   }
@@ -61,7 +61,7 @@ class LoggingWebFilterTest {
     val exchange = createMockExchangeWithSessionID("testSessionID")
     `when`(webFilterChain.filter(exchange)).thenReturn(Mono.empty())
 
-    filter.filter(exchange, webFilterChain)
+    filter.filter(exchange, webFilterChain).block()
 
     verify(webFilterChain).filter(exchange)
     verify(mockLogger).info(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersDetailsIntegrationTest.kt
@@ -21,10 +21,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Get Prisoner Details happy path - blank database`() {
-    var expectedOutput = readFile("testdata/expectation/prisoner-details-2.json")
-    val dob = LocalDate.of(1982, 10, 24)
-    val age = Period.between(dob, LocalDate.now()).years
-    expectedOutput = expectedOutput.replace("REPLACE_WITH_AGE", "$age")
+    val expectedOutput = readFileAndReplaceAge("testdata/expectation/prisoner-details-2.json")
     val nomsId = "123"
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     prisonApiMockServer.stubGetPrisonerImages(nomsId, 200)
@@ -49,10 +46,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-1.sql")
   fun `Get Prisoner Details happy path - database seeded`() {
-    var expectedOutput = readFile("testdata/expectation/prisoner-details-1.json")
-    val dob = LocalDate.of(1982, 10, 24)
-    val age = Period.between(dob, LocalDate.now()).years
-    expectedOutput = expectedOutput.replace("REPLACE_WITH_AGE", "$age")
+    val expectedOutput = readFileAndReplaceAge("testdata/expectation/prisoner-details-1.json")
     val nomsId = "123"
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     prisonApiMockServer.stubGetPrisonerImages(nomsId, 200)
@@ -228,10 +222,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-8.sql")
   fun `Get Prisoner Details happy path - database seeded with assessments submitted`() {
-    var expectedOutput = readFile("testdata/expectation/prisoner-details-3.json")
-    val dob = LocalDate.of(1982, 10, 24)
-    val age = Period.between(dob, LocalDate.now()).years
-    expectedOutput = expectedOutput.replace("REPLACE_WITH_AGE", "$age")
+    val expectedOutput = readFileAndReplaceAge("testdata/expectation/prisoner-details-3.json")
     val nomsId = "123"
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     prisonApiMockServer.stubGetPrisonerImages(nomsId, 200)
@@ -256,10 +247,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-10.sql")
   fun `Get Prisoner Details happy path - database seeded with assessments and resettlement review submitted`() {
-    var expectedOutput = readFile("testdata/expectation/prisoner-details-4.json")
-    val dob = LocalDate.of(1982, 10, 24)
-    val age = Period.between(dob, LocalDate.now()).years
-    expectedOutput = expectedOutput.replace("REPLACE_WITH_AGE", "$age")
+    val expectedOutput = readFileAndReplaceAge("testdata/expectation/prisoner-details-4.json")
     val nomsId = "123"
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     prisonApiMockServer.stubGetPrisonerImages(nomsId, 200)
@@ -279,5 +267,35 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
     val expectedPrisonerEntity = PrisonerEntity(null, nomsId, LocalDateTime.now(), "abc", "xyz", LocalDate.parse("2025-01-23"))
     assertThat(expectedPrisonerEntity).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
       .ignoringFields("id").isEqualTo(prisonerEntity)
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-pathway-statuses-11.sql")
+  fun `Get Prisoner Details - resettlement plan in progress, with no BCST2`() {
+    val nomsId = "123"
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+    prisonApiMockServer.stubGetPrisonerImages(nomsId, 200)
+    deliusApiMockServer.stubGetCrnFromNomsId(nomsId, "abc")
+    deliusApiMockServer.stubGetPersonalDetailsFromCrn("abc", 200)
+    prisonRegisterApiMockServer.stubPrisonList(200)
+
+    webTestClient.get()
+      .uri("/resettlement-passport/prisoner/$nomsId")
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType("application/json")
+      .expectBody()
+      .jsonPath("$.assessmentRequired").isEqualTo(false)
+      .jsonPath("$.resettlementReviewAvailable").isEqualTo(true)
+      .jsonPath("$.immediateNeedsSubmitted").isEqualTo(false)
+      .jsonPath("$.preReleaseSubmitted").isEqualTo(false)
+  }
+
+  private fun readFileAndReplaceAge(resourceName: String): String {
+    val prisonerJson = readFile(resourceName)
+    val dob = LocalDate.of(1982, 10, 24)
+    val age = Period.between(dob, LocalDate.now()).years
+    return prisonerJson.replace("REPLACE_WITH_AGE", "$age")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
@@ -1042,8 +1042,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .bodyValue(
         """
           {
-            "assessmentSkipReason": "COMPLETED_IN_OASYS",
-            "moreInformation": "something or other"
+            "reason": "COMPLETED_IN_OASYS",
+            "moreInfo": "something or other"
           }
         """,
       )
@@ -1072,8 +1072,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .bodyValue(
         """
           {
-            "assessmentSkipReason": "COMPLETED_IN_OASYS",
-            "moreInformation": "something or other"
+            "reason": "COMPLETED_IN_OASYS",
+            "moreInfo": "something or other"
           }
         """,
       )
@@ -1096,8 +1096,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .bodyValue(
         """
           {
-            "assessmentSkipReason": "COMPLETED_IN_OASYS",
-            "moreInformation": "something or other"
+            "reason": "COMPLETED_IN_OASYS",
+            "moreInfo": "something or other"
           }
         """,
       )
@@ -1116,8 +1116,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .bodyValue(
         """
           {
-            "assessmentSkipReason": "COMPLETED_IN_OASYS",
-            "moreInformation": "something or other"
+            "reason": "COMPLETED_IN_OASYS",
+            "moreInfo": "something or other"
           }
         """,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.AssessmentSkipReason
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.ResettlementAssessmentRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.ResettlementAssessmentStatus
@@ -21,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.AssessmentSkipRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PathwayStatusRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.ResettlementAssessmentRepository
 import java.time.LocalDate
@@ -36,6 +38,9 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var pathwayStatusRepository: PathwayStatusRepository
 
+  @Autowired
+  private lateinit var assessmentSkipRepository: AssessmentSkipRepository
+
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-2.sql")
   fun `Post get next assessment page happy path`() {
@@ -44,8 +49,22 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val assessmentType = "BCST2"
     val currentPage = "WHERE_DID_THEY_LIVE"
     val questions = mutableListOf<ResettlementAssessmentRequestQuestionAndAnswer<*>>(
-      ResettlementAssessmentRequestQuestionAndAnswer("WHERE_DID_THEY_LIVE", answer = StringAnswer("PRIVATE_RENTED_HOUSING")),
-      ResettlementAssessmentRequestQuestionAndAnswer("WHERE_DID_THEY_LIVE_ADDRESS", answer = MapAnswer(listOf(mapOf("addressLine1" to "123 fake street", "city" to "Leeds", "postcode" to "LS1 123")))),
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHERE_DID_THEY_LIVE",
+        answer = StringAnswer("PRIVATE_RENTED_HOUSING"),
+      ),
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHERE_DID_THEY_LIVE_ADDRESS",
+        answer = MapAnswer(
+          listOf(
+            mapOf(
+              "addressLine1" to "123 fake street",
+              "city" to "Leeds",
+              "postcode" to "LS1 123",
+            ),
+          ),
+        ),
+      ),
     )
     val body = ResettlementAssessmentRequest(
       questionsAndAnswers = questions,
@@ -75,7 +94,18 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val currentPage = "WHERE_WILL_THEY_LIVE"
     val questions = mutableListOf<ResettlementAssessmentRequestQuestionAndAnswer<*>>(
       ResettlementAssessmentRequestQuestionAndAnswer("WHERE_WILL_THEY_LIVE", answer = StringAnswer("NEW_ADDRESS")),
-      ResettlementAssessmentRequestQuestionAndAnswer("WHAT_IS_THE_ADDRESS", answer = MapAnswer(listOf(mapOf("addressLine1" to "123 fake street", "city" to "Leeds", "postcode" to "LS1 123")))),
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHAT_IS_THE_ADDRESS",
+        answer = MapAnswer(
+          listOf(
+            mapOf(
+              "addressLine1" to "123 fake street",
+              "city" to "Leeds",
+              "postcode" to "LS1 123",
+            ),
+          ),
+        ),
+      ),
     )
     val body = ResettlementAssessmentRequest(
       questionsAndAnswers = questions,
@@ -96,7 +126,18 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val currentPage = "WHERE_WILL_THEY_LIVE"
     val questions = mutableListOf<ResettlementAssessmentRequestQuestionAndAnswer<*>>(
       ResettlementAssessmentRequestQuestionAndAnswer("WHERE_WILL_THEY_LIVE", answer = StringAnswer("NEW_ADDRESS")),
-      ResettlementAssessmentRequestQuestionAndAnswer("WHAT_IS_THE_ADDRESS", answer = MapAnswer(listOf(mapOf("addressLine1" to "123 fake street", "city" to "Leeds", "postcode" to "LS1 123")))),
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHAT_IS_THE_ADDRESS",
+        answer = MapAnswer(
+          listOf(
+            mapOf(
+              "addressLine1" to "123 fake street",
+              "city" to "Leeds",
+              "postcode" to "LS1 123",
+            ),
+          ),
+        ),
+      ),
     )
     val body = ResettlementAssessmentRequest(
       questionsAndAnswers = questions,
@@ -277,17 +318,71 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val sampleAssessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf())
 
     val expectedResettlementAssessments = listOf(
-      ResettlementAssessmentEntity(id = 2, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ACCOMMODATION, statusChangedTo = Status.SUPPORT_DECLINED, assessmentType = ResettlementAssessmentType.RESETTLEMENT_PLAN, assessment = sampleAssessment, creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.COMPLETE, caseNoteText = "Some case notes", createdByUserId = "JSMITH_GEN", submissionDate = null),
       ResettlementAssessmentEntity(
-        id = 1, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-17T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ACCOMMODATION, statusChangedTo = Status.SUPPORT_REQUIRED, assessmentType = ResettlementAssessmentType.BCST2,
-        assessment = ResettlementAssessmentQuestionAndAnswerList(
-          mutableListOf(ResettlementAssessmentSimpleQuestionAndAnswer(questionId = "WHERE_DID_THEY_LIVE", answer = StringAnswer(answer = "NO_PERMANENT_OR_FIXED")), ResettlementAssessmentSimpleQuestionAndAnswer(questionId = "WHERE_WILL_THEY_LIVE_2", answer = StringAnswer(answer = "DOES_NOT_HAVE_ANYWHERE")), ResettlementAssessmentSimpleQuestionAndAnswer(questionId = "SUPPORT_NEEDS", answer = StringAnswer(answer = "SUPPORT_REQUIRED")), ResettlementAssessmentSimpleQuestionAndAnswer(questionId = "CASE_NOTE_SUMMARY", answer = StringAnswer(answer = "My case note summary..."))),
+        id = 2,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
         ),
-        creationDate = LocalDateTime.parse("2024-01-16T14:42:27.905483"), createdBy = "RESETTLEMENTPASSPORT_ADM", assessmentStatus = ResettlementAssessmentStatus.COMPLETE, caseNoteText = "My case note summary...", createdByUserId = "RESETTLEMENTPASSPORT_ADM", submissionDate = null,
+        pathway = Pathway.ACCOMMODATION,
+        statusChangedTo = Status.SUPPORT_DECLINED,
+        assessmentType = ResettlementAssessmentType.RESETTLEMENT_PLAN,
+        assessment = sampleAssessment,
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.COMPLETE,
+        caseNoteText = "Some case notes",
+        createdByUserId = "JSMITH_GEN",
+        submissionDate = null,
+      ),
+      ResettlementAssessmentEntity(
+        id = 1,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-17T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.ACCOMMODATION,
+        statusChangedTo = Status.SUPPORT_REQUIRED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(
+          mutableListOf(
+            ResettlementAssessmentSimpleQuestionAndAnswer(
+              questionId = "WHERE_DID_THEY_LIVE",
+              answer = StringAnswer(answer = "NO_PERMANENT_OR_FIXED"),
+            ),
+            ResettlementAssessmentSimpleQuestionAndAnswer(
+              questionId = "WHERE_WILL_THEY_LIVE_2",
+              answer = StringAnswer(answer = "DOES_NOT_HAVE_ANYWHERE"),
+            ),
+            ResettlementAssessmentSimpleQuestionAndAnswer(
+              questionId = "SUPPORT_NEEDS",
+              answer = StringAnswer(answer = "SUPPORT_REQUIRED"),
+            ),
+            ResettlementAssessmentSimpleQuestionAndAnswer(
+              questionId = "CASE_NOTE_SUMMARY",
+              answer = StringAnswer(answer = "My case note summary..."),
+            ),
+          ),
+        ),
+        creationDate = LocalDateTime.parse("2024-01-16T14:42:27.905483"),
+        createdBy = "RESETTLEMENTPASSPORT_ADM",
+        assessmentStatus = ResettlementAssessmentStatus.COMPLETE,
+        caseNoteText = "My case note summary...",
+        createdByUserId = "RESETTLEMENTPASSPORT_ADM",
+        submissionDate = null,
       ),
     )
     val actualResettlementAssessments = resettlementAssessmentRepository.findAll()
-    assertThat(actualResettlementAssessments).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedResettlementAssessments)
+    assertThat(actualResettlementAssessments).usingRecursiveComparison()
+      .ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedResettlementAssessments)
   }
 
   @Test
@@ -397,7 +492,13 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
         }
         """.trimIndent(),
       )
-      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT"), user = "System User", authSource = "nomis"))
+      .headers(
+        setAuthorisation(
+          roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT"),
+          user = "System User",
+          authSource = "nomis",
+        ),
+      )
       .exchange()
       .expectStatus().isNotFound
       .expectHeader().contentType("application/json")
@@ -432,13 +533,62 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val assessmentType = "BCST2"
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Accommodation BCST2 report\\n\\nCase note related to accommodation", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Attitudes, thinking and behaviour BCST2 report\\n\\nCase note related to Attitudes, thinking and behaviour", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Children, families and communities BCST2 report\\n\\nCase note related to Children, family and communities", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Drugs and alcohol BCST2 report\\n\\nCase note related to Drugs and alcohol", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Education, skills and work BCST2 report\\n\\nCase note related to education, skills and work", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Finance and ID BCST2 report\\n\\nCase note related to Finance and ID", "MDI", 200)
-    caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "BCST", "Case note summary from Health BCST2 report\\n\\nCase note related to Health", "MDI", 200)
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Accommodation BCST2 report\\n\\nCase note related to accommodation",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Attitudes, thinking and behaviour BCST2 report\\n\\nCase note related to Attitudes, thinking and behaviour",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Children, families and communities BCST2 report\\n\\nCase note related to Children, family and communities",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Drugs and alcohol BCST2 report\\n\\nCase note related to Drugs and alcohol",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Education, skills and work BCST2 report\\n\\nCase note related to education, skills and work",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Finance and ID BCST2 report\\n\\nCase note related to Finance and ID",
+      "MDI",
+      200,
+    )
+    caseNotesApiMockServer.stubPostCaseNotes(
+      nomsId,
+      "RESET",
+      "BCST",
+      "Case note summary from Health BCST2 report\\n\\nCase note related to Health",
+      "MDI",
+      200,
+    )
 
     webTestClient.post()
       .uri("resettlement-passport/prisoner/$nomsId/resettlement-assessment/submit?assessmentType=$assessmentType")
@@ -449,30 +599,263 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     // Check correct updates have been made to the database
     val assessmentsInDatabase = resettlementAssessmentRepository.findAll()
     val expectedAssessments = listOf(
-      ResettlementAssessmentEntity(id = 1, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ACCOMMODATION, statusChangedTo = Status.SUPPORT_NOT_REQUIRED, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to accommodation", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 2, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, statusChangedTo = Status.SUPPORT_DECLINED, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to Attitudes, thinking and behaviour", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 3, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, statusChangedTo = Status.SUPPORT_NOT_REQUIRED, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to Children, family and communities", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 4, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.DRUGS_AND_ALCOHOL, statusChangedTo = Status.DONE, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to Drugs and alcohol", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 5, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.EDUCATION_SKILLS_AND_WORK, statusChangedTo = Status.SUPPORT_NOT_REQUIRED, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to education, skills and work", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 6, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.FINANCE_AND_ID, statusChangedTo = Status.IN_PROGRESS, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to Finance and ID", createdByUserId = "USER_1", submissionDate = fakeNow),
-      ResettlementAssessmentEntity(id = 7, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.HEALTH, statusChangedTo = Status.NOT_STARTED, assessmentType = ResettlementAssessmentType.BCST2, assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()), creationDate = LocalDateTime.parse("2023-01-09T19:02:45"), createdBy = "A User", assessmentStatus = ResettlementAssessmentStatus.SUBMITTED, caseNoteText = "Case note related to Health", createdByUserId = "USER_1", submissionDate = fakeNow),
+      ResettlementAssessmentEntity(
+        id = 1,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.ACCOMMODATION,
+        statusChangedTo = Status.SUPPORT_NOT_REQUIRED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to accommodation",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 2,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
+        statusChangedTo = Status.SUPPORT_DECLINED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to Attitudes, thinking and behaviour",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 3,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
+        statusChangedTo = Status.SUPPORT_NOT_REQUIRED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to Children, family and communities",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 4,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.DRUGS_AND_ALCOHOL,
+        statusChangedTo = Status.DONE,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to Drugs and alcohol",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 5,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.EDUCATION_SKILLS_AND_WORK,
+        statusChangedTo = Status.SUPPORT_NOT_REQUIRED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to education, skills and work",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 6,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.FINANCE_AND_ID,
+        statusChangedTo = Status.IN_PROGRESS,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to Finance and ID",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
+      ResettlementAssessmentEntity(
+        id = 7,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.HEALTH,
+        statusChangedTo = Status.NOT_STARTED,
+        assessmentType = ResettlementAssessmentType.BCST2,
+        assessment = ResettlementAssessmentQuestionAndAnswerList(assessment = mutableListOf()),
+        creationDate = LocalDateTime.parse("2023-01-09T19:02:45"),
+        createdBy = "A User",
+        assessmentStatus = ResettlementAssessmentStatus.SUBMITTED,
+        caseNoteText = "Case note related to Health",
+        createdByUserId = "USER_1",
+        submissionDate = fakeNow,
+      ),
     )
 
-    assertThat(assessmentsInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedAssessments)
+    assertThat(assessmentsInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
+      .isEqualTo(expectedAssessments)
 
     // Check pathway statuses have been updated
     val pathwayStatusesInDatabase = pathwayStatusRepository.findAll()
     val expectedPathwayStatuses = listOf(
-      PathwayStatusEntity(id = 1, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ACCOMMODATION, status = Status.SUPPORT_NOT_REQUIRED, updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.924738")),
-      PathwayStatusEntity(id = 2, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.SUPPORT_DECLINED, updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.966093")),
-      PathwayStatusEntity(id = 3, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.SUPPORT_NOT_REQUIRED, updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.984784")),
-      PathwayStatusEntity(id = 4, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.DRUGS_AND_ALCOHOL, status = Status.DONE, updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.003119")),
-      PathwayStatusEntity(id = 5, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.EDUCATION_SKILLS_AND_WORK, status = Status.SUPPORT_NOT_REQUIRED, updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.023966")),
-      PathwayStatusEntity(id = 6, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.FINANCE_AND_ID, status = Status.IN_PROGRESS, updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.042654")),
-      PathwayStatusEntity(id = 7, prisoner = PrisonerEntity(id = 1, nomsId = "ABC1234", creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"), crn = "123", prisonId = "MDI", releaseDate = LocalDate.parse("2030-09-12")), pathway = Pathway.HEALTH, status = Status.NOT_STARTED, updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.062076")),
+      PathwayStatusEntity(
+        id = 1,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.ACCOMMODATION,
+        status = Status.SUPPORT_NOT_REQUIRED,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.924738"),
+      ),
+      PathwayStatusEntity(
+        id = 2,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
+        status = Status.SUPPORT_DECLINED,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.966093"),
+      ),
+      PathwayStatusEntity(
+        id = 3,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
+        status = Status.SUPPORT_NOT_REQUIRED,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:42.984784"),
+      ),
+      PathwayStatusEntity(
+        id = 4,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.DRUGS_AND_ALCOHOL,
+        status = Status.DONE,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.003119"),
+      ),
+      PathwayStatusEntity(
+        id = 5,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.EDUCATION_SKILLS_AND_WORK,
+        status = Status.SUPPORT_NOT_REQUIRED,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.023966"),
+      ),
+      PathwayStatusEntity(
+        id = 6,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.FINANCE_AND_ID,
+        status = Status.IN_PROGRESS,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.042654"),
+      ),
+      PathwayStatusEntity(
+        id = 7,
+        prisoner = PrisonerEntity(
+          id = 1,
+          nomsId = "ABC1234",
+          creationDate = LocalDateTime.parse("2023-08-16T12:21:38.709"),
+          crn = "123",
+          prisonId = "MDI",
+          releaseDate = LocalDate.parse("2030-09-12"),
+        ),
+        pathway = Pathway.HEALTH,
+        status = Status.NOT_STARTED,
+        updatedDate = LocalDateTime.parse("2024-01-31T14:48:43.062076"),
+      ),
     )
 
-    assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
+    assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
+      .isEqualTo(expectedPathwayStatuses)
   }
 
   @Test
@@ -645,5 +1028,101 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput)
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-2.sql")
+  fun `Can skip BCST2 assessment when it is not started`() {
+    val nomsId = "G4161UF"
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/skip?assessmentType=BCST2")
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+            "assessmentSkipReason": "COMPLETED_IN_OASYS",
+            "moreInformation": "something or other"
+          }
+        """,
+      )
+      .exchange()
+      .expectStatus().isNoContent
+
+    val savedSkip = assessmentSkipRepository.getReferenceById(1)
+
+    assertThat(savedSkip.assessmentType).isEqualTo(ResettlementAssessmentType.BCST2)
+    assertThat(savedSkip.prisonerId).isEqualTo(1)
+    assertThat(savedSkip.reason).isEqualTo(AssessmentSkipReason.COMPLETED_IN_OASYS)
+    assertThat(savedSkip.moreInfo).isEqualTo("something or other")
+    assertThat(savedSkip.createdBy).isEqualTo("RESETTLEMENTPASSPORT_ADM")
+    assertThat(savedSkip.creationDate).isNotNull()
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-7.sql")
+  fun `Cannot skip BCST2 when it is started`() {
+    val nomsId = "G4161UF"
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/skip?assessmentType=BCST2")
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+            "assessmentSkipReason": "COMPLETED_IN_OASYS",
+            "moreInformation": "something or other"
+          }
+        """,
+      )
+      .exchange()
+      .expectStatus()
+      .isBadRequest()
+      .expectBody()
+      .jsonPath("$.developerMessage")
+      .value { message: String -> assertThat(message).contains("Cannot skip assessment that has already been started") }
+  }
+
+  @Test
+  fun `Skip assessment requires edit role`() {
+    val nomsId = "G4161UF"
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/skip?assessmentType=BCST2")
+      .headers(setAuthorisation(roles = listOf("BAD_ROLE")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+            "assessmentSkipReason": "COMPLETED_IN_OASYS",
+            "moreInformation": "something or other"
+          }
+        """,
+      )
+      .exchange()
+      .expectStatus()
+      .isForbidden()
+  }
+
+  @Test
+  fun `Skip assessment requires auth`() {
+    val nomsId = "G4161UF"
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/skip?assessmentType=BCST2")
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+            "assessmentSkipReason": "COMPLETED_IN_OASYS",
+            "moreInformation": "something or other"
+          }
+        """,
+      )
+      .exchange()
+      .expectStatus()
+      .isUnauthorized()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PoPUserOTPServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PoPUserOTPServiceTest.kt
@@ -202,7 +202,14 @@ class PoPUserOTPServiceTest {
       dateOfBirth = LocalDate.parse("1982-10-24"),
       releaseDate = testDate.toLocalDate().plusMonths(6),
     )
-    val prisonerSearch = Prisoner(prisonerPersonal, null, false, false)
+    val prisonerSearch = Prisoner(
+      prisonerPersonal,
+      null,
+      assessmentRequired = false,
+      resettlementReviewAvailable = false,
+      immediateNeedsSubmitted = true,
+      preReleaseSubmitted = true,
+    )
 
     Mockito.`when`(prisoner.id?.let { prisonerRepository.findById(it) }).thenReturn(Optional.of(prisoner))
     Mockito.lenient().`when`(popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(oneLoginUserData.otp, LocalDate.parse("1982-10-24"), LocalDateTime.now())).thenReturn(popUserOTPEntity)
@@ -281,7 +288,14 @@ class PoPUserOTPServiceTest {
       dateOfBirth = LocalDate.parse("1982-10-24"),
       releaseDate = testDate.toLocalDate().plusMonths(6),
     )
-    val prisonerSearch = Prisoner(prisonerPersonal, null, false, false)
+    val prisonerSearch = Prisoner(
+      prisonerPersonal,
+      null,
+      false,
+      resettlementReviewAvailable = false,
+      immediateNeedsSubmitted = true,
+      preReleaseSubmitted = true,
+    )
 
     Mockito.`when`(prisoner.id?.let { prisonerRepository.findById(it) }).thenReturn(Optional.of(prisoner))
     Mockito.lenient().`when`(popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(oneLoginUserData.otp, LocalDate.parse("1982-10-24"), LocalDateTime.now())).thenReturn(popUserOTPEntity)

--- a/src/test/resources/testdata/expectation/prisoner-details-1.json
+++ b/src/test/resources/testdata/expectation/prisoner-details-1.json
@@ -54,5 +54,7 @@
     }
   ],
   "assessmentRequired": true,
-  "resettlementReviewAvailable":false
+  "resettlementReviewAvailable":false,
+  "immediateNeedsSubmitted": false,
+  "preReleaseSubmitted": false
 }

--- a/src/test/resources/testdata/expectation/prisoner-details-2.json
+++ b/src/test/resources/testdata/expectation/prisoner-details-2.json
@@ -54,5 +54,7 @@
     }
   ],
   "assessmentRequired": true,
-  "resettlementReviewAvailable":false
+  "resettlementReviewAvailable":false,
+  "immediateNeedsSubmitted": false,
+  "preReleaseSubmitted": false
 }

--- a/src/test/resources/testdata/expectation/prisoner-details-3.json
+++ b/src/test/resources/testdata/expectation/prisoner-details-3.json
@@ -54,5 +54,7 @@
     }
   ],
   "assessmentRequired": false,
-  "resettlementReviewAvailable":true
+  "resettlementReviewAvailable":true,
+  "immediateNeedsSubmitted": true,
+  "preReleaseSubmitted": false
 }

--- a/src/test/resources/testdata/expectation/prisoner-details-4.json
+++ b/src/test/resources/testdata/expectation/prisoner-details-4.json
@@ -54,5 +54,7 @@
     }
   ],
   "assessmentRequired": false,
-  "resettlementReviewAvailable":false
+  "resettlementReviewAvailable":false,
+  "immediateNeedsSubmitted": true,
+  "preReleaseSubmitted": true
 }

--- a/src/test/resources/testdata/expectation/prisoner-details-5.json
+++ b/src/test/resources/testdata/expectation/prisoner-details-5.json
@@ -54,5 +54,7 @@
     }
   ],
   "assessmentRequired": true,
-  "resettlementReviewAvailable":false
+  "resettlementReviewAvailable":false,
+  "immediateNeedsSubmitted": false,
+  "preReleaseSubmitted": false
 }

--- a/src/test/resources/testdata/sql/clear-all-data.sql
+++ b/src/test/resources/testdata/sql/clear-all-data.sql
@@ -16,5 +16,7 @@ DELETE from id_application;
 ALTER SEQUENCE id_application_id_seq RESTART WITH 1;
 DELETE from delius_contact;
 ALTER SEQUENCE delius_contact_id_seq RESTART WITH 1;
+DELETE from assessment_skip;
+ALTER SEQUENCE assessment_skip_id_seq RESTART WITH 1;
 DELETE from prisoner;
 ALTER SEQUENCE prisoner_id_seq RESTART WITH 1;

--- a/src/test/resources/testdata/sql/seed-pathway-statuses-11.sql
+++ b/src/test/resources/testdata/sql/seed-pathway-statuses-11.sql
@@ -1,0 +1,74 @@
+INSERT INTO prisoner
+(id, noms_id, creation_date, crn, prison_id, release_date)
+VALUES(1, '123', '2023-08-16 12:21:38.709','abc', 'xyz', '2025-01-23');
+INSERT INTO prisoner
+(id, noms_id, creation_date, crn, prison_id, release_date)
+VALUES(2, '456', '2023-08-17 12:25:45.306', 'def', 'xyz', '2024-02-02');
+INSERT INTO prisoner
+(id, noms_id, creation_date, crn, prison_id, release_date)
+VALUES(3, '789', '2023-08-17 12:26:03.441', 'ghi', 'xyz', '2026-10-30');
+
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(1, 1, 'ACCOMMODATION', 'NOT_STARTED', '2023-08-16 12:21:44.234');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(2, 1, 'ATTITUDES_THINKING_AND_BEHAVIOUR', 'IN_PROGRESS', '2023-08-17 12:28:10.466');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(3, 1, 'CHILDREN_FAMILIES_AND_COMMUNITY', 'SUPPORT_NOT_REQUIRED', '2023-08-17 12:28:10.475');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(4, 1, 'DRUGS_AND_ALCOHOL', 'SUPPORT_DECLINED', '2023-08-17 12:28:10.479');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(5, 1, 'EDUCATION_SKILLS_AND_WORK', 'DONE', '2023-08-17 12:28:10.483');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(6, 1, 'FINANCE_AND_ID', 'IN_PROGRESS', '2023-08-17 12:28:10.490');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(7, 1, 'HEALTH', 'SUPPORT_NOT_REQUIRED', '2023-08-17 12:28:10.493');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(8, 2, 'ACCOMMODATION', 'IN_PROGRESS', '2023-08-17 12:30:03.834');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(9, 2, 'ATTITUDES_THINKING_AND_BEHAVIOUR', 'SUPPORT_NOT_REQUIRED', '2023-08-17 12:30:03.841');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(10, 2, 'CHILDREN_FAMILIES_AND_COMMUNITY', 'SUPPORT_DECLINED', '2023-08-17 12:30:03.846');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(11, 2, 'DRUGS_AND_ALCOHOL', 'DONE', '2023-08-17 12:30:03.849');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(12, 2, 'EDUCATION_SKILLS_AND_WORK', 'NOT_STARTED', '2023-08-17 12:30:03.851');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(13, 2, 'FINANCE_AND_ID', 'IN_PROGRESS', '2023-08-17 12:30:03.855');
+INSERT INTO pathway_status
+(id, prisoner_id, pathway, status, updated_date)
+VALUES(14, 2, 'HEALTH', 'SUPPORT_NOT_REQUIRED', '2023-08-17 12:30:03.858');
+
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(8, 1, 'ACCOMMODATION', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(9, 1, 'ATTITUDES_THINKING_AND_BEHAVIOUR', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(11, 1, 'CHILDREN_FAMILIES_AND_COMMUNITY', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(12, 1, 'DRUGS_AND_ALCOHOL', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(13, 1, 'EDUCATION_SKILLS_AND_WORK', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(14, 1, 'FINANCE_AND_ID', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');
+INSERT INTO resettlement_assessment
+(id, prisoner_id, pathway, assessment_status, assessment_type, assessment, status_changed_to, created_date, created_by)
+VALUES(15, 1, 'HEALTH', 'COMPLETE', 'RESETTLEMENT_PLAN', '{"assessment": []}'::jsonb, 'NOT_STARTED', '2023-10-16 12:21:38.709','Prison Officer');


### PR DESCRIPTION
* Add new endpoint to persist assessment skip form
* Refactor loading assessment status - 1 DB query instead of 7
* Adjust flags on GET prisoner response to handle resettlement plan happening before BCST2
* Refactor LoggingWebFilterTest as it was randomly failing for me