### PR TITLE
PSFR-1370 Bump max memory for codecs

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/WebClientConfiguration.kt
@@ -120,7 +120,7 @@ class WebClientConfiguration(
       .clientConnector(ReactorClientHttpConnector(httpClient))
       .filter(oauth2Client)
       .codecs { codecs ->
-        codecs.defaultCodecs().maxInMemorySize(2 * 1024 * 1024)
+        codecs.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)
         codecs.defaultCodecs().jackson2JsonEncoder(
           Jackson2JsonEncoder(
             objectMapper,


### PR DESCRIPTION
To try to fix `Caused by: org.springframework.core.io.buffer.DataBufferLimitException: Exceeded limit on max bytes to buffer : 2097152` error in preprod