### PR TITLE
PLT-373 Create prisoner record on admission event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
@@ -14,13 +14,13 @@ import java.time.LocalDateTime
 data class PrisonerEntity(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val id: Long?,
+  val id: Long? = null,
 
   @Column(name = "noms_id")
   val nomsId: String,
 
   @Column(name = "creation_date")
-  val creationDate: LocalDateTime,
+  val creationDate: LocalDateTime = LocalDateTime.now(),
 
   @Column(name = "crn")
   var crn: String?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerService.kt
@@ -275,14 +275,12 @@ class PrisonerService(
     setDisplayedReleaseDate(prisonerSearch)
 
     // Add initial pathway statuses if required
-    pathwayAndStatusService.addPrisonerAndInitialPathwayStatus(
+    val prisonerEntity = pathwayAndStatusService.getOrCreatePrisoner(
       nomsId,
       prisonerSearch.prisonId,
       prisonerSearch.displayReleaseDate,
     )
 
-    val prisonerEntity = prisonerRepository.findByNomsId(nomsId)
-      ?: throw ResourceNotFoundException("Unable to find prisoner $nomsId in database.")
     val prisonerImageDetailsList = prisonApiService.findPrisonerImageDetails(nomsId)
     var prisonerImage: PrisonerImage? = null
     prisonerImageDetailsList.forEach {
@@ -470,9 +468,7 @@ class PrisonerService(
     }
   }
 
-  fun getPrisonerEntity(nomsId: String): PrisonerEntity {
-    return prisonerRepository.findByNomsId(nomsId) ?: throw ResourceNotFoundException("Unable to find prisoner $nomsId in database.")
-  }
+  fun getPrisonerEntity(nomsId: String): PrisonerEntity = prisonerRepository.findByNomsId(nomsId) ?: throw ResourceNotFoundException("Unable to find prisoner $nomsId in database.")
 }
 
 private data class AssessmentRequiredResult(

--- a/src/main/resources/db/migration/V1_49_indexes.sql
+++ b/src/main/resources/db/migration/V1_49_indexes.sql
@@ -1,0 +1,4 @@
+create index prisoner_prison_id on prisoner(prison_id);
+create index prisoner_release_date on prisoner(release_date);
+
+create index pathway_status_prisoner_id on pathway_status(prisoner_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/events/DomainEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/events/DomainEventTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+
+class DomainEventTest {
+  private val objectMapper = Jackson2ObjectMapperBuilder.json().build<ObjectMapper>()
+
+  @Test
+  fun `Can get noms id`() {
+    val event: DomainEvent = readEvent()
+
+    assertThat(event.personReference.findNomsId()).isEqualTo("A4092EA")
+  }
+
+  private fun readEvent(): DomainEvent {
+    val envelope: MessageEnvelope = objectMapper.readValue(readFile("testdata/events/recall-event.json"))
+    val event: DomainEvent = objectMapper.readValue(envelope.message)
+    return event
+  }
+
+  @Test
+  fun `Can get prison id`() {
+    val event: DomainEvent = readEvent()
+
+    assertThat(event.prisonId()).isEqualTo("SWI")
+  }
+
+  @Test
+  fun `Can get movement reason code`() {
+    val event: DomainEvent = readEvent()
+
+    assertThat(event.movementReasonCode()).isEqualTo("24")
+  }
+}


### PR DESCRIPTION
* Create new prisoner record when we do not have one for that nomsid when an admission event is recieved
* Add some indexes for common app queries on the prisoner and pathway_status tables this wall caused to have much higher record count