### PR TITLE
PLT-425 Restructure dockerfile

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -124,3 +124,12 @@ tasks.named<BootRun>("bootRun") {
 dependencyCheck {
   suppressionFiles.add("owasp-suppressions.xml")
 }
+
+abstract class EchoTask : DefaultTask() {
+  @TaskAction
+  fun action() {
+    println("Dependencies downloaded")
+  }
+}
+
+tasks.register<EchoTask>("downloadDependencies")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,14 +4,11 @@ services:
   hmpps-resettlement-passport-api:
     build:
       context: .
-
     networks:
       - hmpps
     container_name: hmpps-resettlement-passport-api
     ports:
       - "8080:8080"
-    healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health/ping" ]
     environment:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=dev


### PR DESCRIPTION
For improved layer caching.
Download gradle + deps as one layer so that only needs to run if gradle version/dependencies change.
Do apt update in separate layer so package installation can be cached if no changes.

Use no-gui versions of libreoffice to require fewer unused packages