### PR TITLE
PLT-481 Documents api tweaks

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/DocumentStorageResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/DocumentStorageResourceController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RequestPart
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.multipart.MultipartFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
@@ -52,11 +53,13 @@ class DocumentStorageResourceController(
     @Schema(example = "AXXXS", required = true)
     @PathVariable("nomsId")
     nomsId: String,
-    @RequestParam("file")
+    @RequestPart
     file: MultipartFile,
     @RequestParam(defaultValue = "LICENCE_CONDITIONS", required = false)
     category: DocumentCategory,
-  ) = uploadService.processDocument(nomsId, file, category)
+    @RequestPart(required = false)
+    originalFilename: String?
+  ) = uploadService.processDocument(nomsId, file, originalFilename, category)
 
   @GetMapping("/documents/{documentId}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/DocumentStorageResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/DocumentStorageResourceController.kt
@@ -22,6 +22,7 @@ import org.springframework.web.multipart.MultipartFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.DocumentCategory
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.DocumentService
+import java.time.LocalDateTime
 
 @RestController
 @Validated
@@ -58,7 +59,7 @@ class DocumentStorageResourceController(
     @RequestParam(defaultValue = "LICENCE_CONDITIONS", required = false)
     category: DocumentCategory,
     @RequestPart(required = false)
-    originalFilename: String?
+    originalFilename: String?,
   ) = uploadService.processDocument(nomsId, file, originalFilename, category)
 
   @GetMapping("/documents/{documentId}/download", produces = [MediaType.APPLICATION_PDF_VALUE])
@@ -186,13 +187,15 @@ class DocumentStorageResourceController(
     @PathVariable("nomsId")
     @Parameter(required = true)
     nomsId: String,
-    @RequestParam(required = true)
-    category: DocumentCategory,
+    @RequestParam(required = false)
+    category: DocumentCategory?,
   ): Collection<DocumentResponse> = uploadService.listDocuments(nomsId, category)
-    .map { DocumentResponse(it.id!!, it.originalDocumentFileName) }
+    .map { DocumentResponse(it.id!!, it.originalDocumentFileName, it.creationDate, it.category) }
 
   data class DocumentResponse(
     val id: Long,
     val fileName: String,
+    val creationDate: LocalDateTime,
+    val category: DocumentCategory,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentService.kt
@@ -46,9 +46,8 @@ class DocumentService(
     category: DocumentCategory,
   ): Result<DocumentsEntity, VirusFound> =
     forExistingPrisoner(nomsId) {
-      val filename: String = originalFilename ?: document.originalFilename
-      ?: throw ValidationException("filename is required")
-      println("$filename $originalFilename")
+      val filename: String =
+        originalFilename ?: document.originalFilename ?: throw ValidationException("filename is required")
 
       val extension = filename.substringAfterLast(".", "")
       if (extension !in allowableFileExtensions) {
@@ -150,6 +149,10 @@ class DocumentService(
 
   data class VirusFoundEvent(val nomsId: String, val foundViruses: Map<String, Collection<String>>)
 
-  fun listDocuments(nomsId: String, category: DocumentCategory): Collection<DocumentsEntity> =
-    documentsRepository.findAllByNomsIdAndCategory(nomsId, category)
+  fun listDocuments(nomsId: String, category: DocumentCategory?): Collection<DocumentsEntity> =
+    if (category == null) {
+      documentsRepository.findAllByNomsId(nomsId)
+    } else {
+      documentsRepository.findAllByNomsIdAndCategory(nomsId, category)
+    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentServiceTest.kt
@@ -69,7 +69,7 @@ class DocumentServiceTest {
     whenever(prisonerRepository.findByNomsId("acb")).thenReturn(prisonerEntity)
     whenever(documentsRepository.save(any())).thenReturn(documentsEntity)
     whenever(documentConversionService.convert(eq(file))).thenReturn(pdfDocumentKey)
-    val response = documentService.processDocument("acb", file, DocumentCategory.LICENCE_CONDITIONS)
+    val response = documentService.processDocument("acb", file, null, DocumentCategory.LICENCE_CONDITIONS)
     Assertions.assertEquals(documentsEntity, response.valueOrNull())
   }
 


### PR DESCRIPTION
* Add original filename field for ui to easily send the original filename (rather than it's randomly generated temp one)
* Add ability to get documents for all categories on the list documents endpoint