### PR TITLE
RSP-1819 Add legacy profile tag to prisoner table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
@@ -24,8 +24,8 @@ data class PrisonerEntity(
   @Column(name = "prison_id")
   var prisonId: String?,
 
-  @Column(name = "legacy_profile")
-  var legacyProfile: Boolean? = null,
+  @Column(name = "support_needs_legacy_profile")
+  var supportNeedsLegacyProfile: Boolean? = null,
 ) {
   fun id() = id ?: throw IllegalStateException("Tried to get id before saving")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/PrisonerEntity.kt
@@ -23,6 +23,9 @@ data class PrisonerEntity(
 
   @Column(name = "prison_id")
   var prisonId: String?,
+
+  @Column(name = "legacy_profile")
+  var legacyProfile: Boolean? = null,
 ) {
   fun id() = id ?: throw IllegalStateException("Tried to get id before saving")
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
@@ -329,9 +329,11 @@ class ResettlementAssessmentController(
     @Schema(hidden = true)
     @RequestHeader("Authorization")
     auth: String,
+    @RequestParam("supportNeedsLegacyProfile")
+    supportNeedsLegacyProfile: Boolean = true,
   ): ResettlementAssessmentSubmitResponse {
     auditService.audit(AuditAction.SUBMIT_ASSESSMENT, nomsId, auth, buildDetails(assessmentType, null))
-    return resettlementAssessmentService.submitResettlementAssessmentByNomsId(nomsId, assessmentType, useNewDeliusCaseNoteFormat, useNewDpsCaseNoteFormat, auth, resettlementAssessmentStrategy)
+    return resettlementAssessmentService.submitResettlementAssessmentByNomsId(nomsId, assessmentType, useNewDeliusCaseNoteFormat, useNewDpsCaseNoteFormat, auth, resettlementAssessmentStrategy, supportNeedsLegacyProfile)
   }
 
   @GetMapping("/{nomsId}/resettlement-assessment/{pathway}/latest", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusService.kt
@@ -65,6 +65,7 @@ class PathwayAndStatusService(
         PrisonerEntity(
           nomsId = nomsId,
           prisonId = prisonId,
+          supportNeedsLegacyProfile = false,
         ),
       )
       Pathway.entries.forEach {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentResetService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentResetService.kt
@@ -14,6 +14,7 @@ class ResettlementAssessmentResetService(
   private val resettlementAssessmentService: ResettlementAssessmentService,
   private val caseNotesService: CaseNotesService,
   private val pathwayAndStatusService: PathwayAndStatusService,
+  private val supportNeedsLegacyProfileService: SupportNeedsLegacyProfileService,
 ) {
 
   @Transactional
@@ -29,6 +30,9 @@ class ResettlementAssessmentResetService(
     resettlementAssessmentService.deleteAllResettlementAssessments(nomsId)
     Pathway.entries.forEach { pathway -> pathwayAndStatusService.updatePathwayStatus(nomsId, PathwayAndStatus(pathway, Status.NOT_STARTED)) }
     caseNotesService.sendProfileResetCaseNote(nomsId, userId, reason)
+
+    // Set the supportNeedsLegacyProfile to false
+    supportNeedsLegacyProfileService.setSupportNeedsLegacyFlag(nomsId, false)
   }
 
   fun getReason(profileReset: ProfileReset): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
@@ -53,6 +53,7 @@ class ResettlementAssessmentService(
   private val caseNoteRetryRepository: CaseNoteRetryRepository,
   private val profileTagsRepository: ProfileTagsRepository,
   @Value("\${psfr.base.url}") private val psfrBaseUrl: String,
+  private val supportNeedsLegacyProfileService: SupportNeedsLegacyProfileService,
 ) {
 
   companion object {
@@ -106,7 +107,7 @@ class ResettlementAssessmentService(
     )
 
   @Transactional
-  fun submitResettlementAssessmentByNomsId(nomsId: String, assessmentType: ResettlementAssessmentType, useNewDeliusCaseNoteFormat: Boolean, useNewDpsCaseNoteFormat: Boolean, auth: String, resettlementAssessmentStrategy: ResettlementAssessmentStrategy): ResettlementAssessmentSubmitResponse {
+  fun submitResettlementAssessmentByNomsId(nomsId: String, assessmentType: ResettlementAssessmentType, useNewDeliusCaseNoteFormat: Boolean, useNewDpsCaseNoteFormat: Boolean, auth: String, resettlementAssessmentStrategy: ResettlementAssessmentStrategy, supportNeedsLegacyProfile: Boolean): ResettlementAssessmentSubmitResponse {
     // Check auth - must be NOMIS
     val authSource = getClaimFromJWTToken(auth, "auth_source")?.lowercase()
     if (authSource != "nomis") {
@@ -246,6 +247,12 @@ class ResettlementAssessmentService(
         )
       },
     )
+
+    // Set the supportNeedsLegacyProfile flag (if needed)
+    if (supportNeedsLegacyProfile && assessmentType == ResettlementAssessmentType.RESETTLEMENT_PLAN) {
+      supportNeedsLegacyProfileService.setSupportNeedsLegacyFlag(nomsId, true)
+    }
+
     return ResettlementAssessmentSubmitResponse(deliusCaseNoteFailed = failedCaseNotes.isNotEmpty())
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsLegacyProfileService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsLegacyProfileService.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ResourceNotFoundException
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
+
+@Service
+class SupportNeedsLegacyProfileService(private val prisonerRepository: PrisonerRepository) {
+  @Transactional
+  fun setSupportNeedsLegacyFlag(nomsId: String, flag: Boolean) {
+    val prisoner = prisonerRepository.findByNomsId(nomsId) ?: throw ResourceNotFoundException("Unable to find prisoner $nomsId in database.")
+    prisoner.supportNeedsLegacyProfile = flag
+    prisonerRepository.save(prisoner)
+  }
+}

--- a/src/main/resources/db/migration/V1_73__add_legacy_profile_flag_to_prisoner.sql
+++ b/src/main/resources/db/migration/V1_73__add_legacy_profile_flag_to_prisoner.sql
@@ -1,0 +1,1 @@
+alter table prisoner add legacy_profile boolean;

--- a/src/main/resources/db/migration/V1_73__add_legacy_profile_flag_to_prisoner.sql
+++ b/src/main/resources/db/migration/V1_73__add_legacy_profile_flag_to_prisoner.sql
@@ -1,1 +1,0 @@
-alter table prisoner add legacy_profile boolean;

--- a/src/main/resources/db/migration/V1_74__add_legacy_profile_flag_to_prisoner.sql
+++ b/src/main/resources/db/migration/V1_74__add_legacy_profile_flag_to_prisoner.sql
@@ -1,0 +1,1 @@
+alter table prisoner add support_needs_legacy_profile boolean;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersDetailsIntegrationTest.kt
@@ -42,7 +42,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
       .expectBody().json(expectedOutput, JsonCompareMode.STRICT)
 
     val prisonerEntity1 = prisonerRepository.findByNomsId("123")
-    val expectedPrisonerEntity1 = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI")
+    val expectedPrisonerEntity1 = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI", false)
     assertThat(expectedPrisonerEntity1).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
       .ignoringFields("id").isEqualTo(prisonerEntity1)
 
@@ -60,7 +60,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
       .expectBody().json(expectedOutput, JsonCompareMode.STRICT)
 
     val prisonerEntity2 = prisonerRepository.findByNomsId("123")
-    val expectedPrisonerEntity2 = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI")
+    val expectedPrisonerEntity2 = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI", false)
     assertThat(expectedPrisonerEntity2).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
       .ignoringFields("id").isEqualTo(prisonerEntity2)
   }
@@ -111,7 +111,7 @@ class PrisonersDetailsIntegrationTest : IntegrationTestBase() {
       .expectBody().json(expectedOutput, JsonCompareMode.STRICT)
 
     val prisonerEntity = prisonerRepository.findByNomsId("123")
-    val expectedPrisonerEntity = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI")
+    val expectedPrisonerEntity = PrisonerEntity(null, nomsId, LocalDateTime.now(), "MDI", false)
     assertThat(expectedPrisonerEntity).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java)
       .ignoringFields("id").isEqualTo(prisonerEntity)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerRepositoryTest.kt
@@ -52,7 +52,7 @@ class PrisonerRepositoryTest : RepositoryTestBase() {
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `test edit legacy profile on prisoner`() {
     val prisonerFromDatabase = prisonerRepository.findById(1).get()
-    prisonerFromDatabase.legacyProfile = true
+    prisonerFromDatabase.supportNeedsLegacyProfile = true
     prisonerRepository.save(prisonerFromDatabase)
 
     assertThat(prisonerFromDatabase).usingRecursiveComparison().isEqualTo(PrisonerEntity(1, "G4161UF", LocalDateTime.parse("2024-02-19T09:36:28.713421"), "MDI", true))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerRepositoryTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.context.jdbc.Sql
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import java.time.LocalDateTime
 
@@ -35,5 +36,25 @@ class PrisonerRepositoryTest : RepositoryTestBase() {
     )
 
     assertThat(prisonerRepository.findDistinctPrisonIds()).isEqualTo(listOf("AA1", "AA2", "AA3", "AA4"))
+  }
+
+  @Test
+  fun `test persist new prisoner with legacy profile`() {
+    val prisoner = PrisonerEntity(null, "NOM1234", LocalDateTime.parse("2025-02-18T12:00:01"), "xyz1", false)
+    prisonerRepository.save(prisoner)
+
+    val prisonerFromDatabase = prisonerRepository.findAll()[0]
+
+    assertThat(prisonerFromDatabase).usingRecursiveComparison().isEqualTo(prisoner)
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
+  fun `test edit legacy profile on prisoner`() {
+    val prisonerFromDatabase = prisonerRepository.findById(1).get()
+    prisonerFromDatabase.legacyProfile = true
+    prisonerRepository.save(prisonerFromDatabase)
+
+    assertThat(prisonerFromDatabase).usingRecursiveComparison().isEqualTo(PrisonerEntity(1, "G4161UF", LocalDateTime.parse("2024-02-19T09:36:28.713421"), "MDI", true))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentResetServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentResetServiceTest.kt
@@ -38,12 +38,16 @@ class ResettlementAssessmentResetServiceTest {
   @Mock
   private lateinit var pathwayAndStatusService: PathwayAndStatusService
 
+  @Mock
+  private lateinit var supportNeedsLegacyProfileService: SupportNeedsLegacyProfileService
+
   @BeforeEach
   fun beforeEach() {
     resettlementAssessmentResetService = ResettlementAssessmentResetService(
       resettlementAssessmentService,
       caseNotesService,
       pathwayAndStatusService,
+      supportNeedsLegacyProfileService,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
@@ -98,6 +98,9 @@ class ResettlementAssessmentServiceTest {
   private lateinit var pathwayStatusRepository: PathwayStatusRepository
 
   @Mock
+  private lateinit var supportNeedsLegacyProfileService: SupportNeedsLegacyProfileService
+
+  @Mock
   private val testDate = LocalDateTime.parse("2023-08-16T12:00:00")
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
@@ -114,6 +117,7 @@ class ResettlementAssessmentServiceTest {
       caseNoteRetryRepository,
       profileTagsRepository,
       "https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk",
+      supportNeedsLegacyProfileService
     )
 
     resettlementAssessmentStrategy = ResettlementAssessmentStrategy(

--- a/src/test/resources/testdata/expectation/sar-with-dates-1.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-1.json
@@ -4,7 +4,8 @@
       "id": 1,
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
-      "prisonId": null
+      "prisonId": null,
+      "legacyProfile": null
     },
     "assessment": null,
     "bankApplication": null,

--- a/src/test/resources/testdata/expectation/sar-with-dates-1.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-1.json
@@ -5,7 +5,7 @@
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
       "prisonId": null,
-      "legacyProfile": null
+      "supportNeedsLegacyProfile": null
     },
     "assessment": null,
     "bankApplication": null,

--- a/src/test/resources/testdata/expectation/sar-with-dates-2.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-2.json
@@ -5,7 +5,7 @@
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
       "prisonId": null,
-      "legacyProfile": null
+      "supportNeedsLegacyProfile": null
     },
     "assessment": {
       "id": 1,
@@ -25,7 +25,7 @@
         "nomsId": "G1458GV",
         "creationDate": "2024-01-01T12:21:38.709",
         "prisonId": null,
-        "legacyProfile": null
+        "supportNeedsLegacyProfile": null
       },
       "logs": [],
       "applicationSubmittedDate": "2023-08-16T12:21:38.709",

--- a/src/test/resources/testdata/expectation/sar-with-dates-2.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-2.json
@@ -4,7 +4,8 @@
       "id": 1,
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
-      "prisonId": null
+      "prisonId": null,
+      "legacyProfile": null
     },
     "assessment": {
       "id": 1,
@@ -23,7 +24,8 @@
         "id": 1,
         "nomsId": "G1458GV",
         "creationDate": "2024-01-01T12:21:38.709",
-        "prisonId": null
+        "prisonId": null,
+        "legacyProfile": null
       },
       "logs": [],
       "applicationSubmittedDate": "2023-08-16T12:21:38.709",

--- a/src/test/resources/testdata/expectation/sar-without-dates.json
+++ b/src/test/resources/testdata/expectation/sar-without-dates.json
@@ -5,7 +5,7 @@
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
       "prisonId": null,
-      "legacyProfile": null
+      "supportNeedsLegacyProfile": null
     },
     "assessment": {
       "id": 1,
@@ -25,7 +25,7 @@
         "nomsId": "G1458GV",
         "creationDate": "2024-01-01T12:21:38.709",
         "prisonId": null,
-        "legacyProfile": null
+        "supportNeedsLegacyProfile": null
       },
       "logs": [],
       "applicationSubmittedDate": "2023-08-16T12:21:38.709",

--- a/src/test/resources/testdata/expectation/sar-without-dates.json
+++ b/src/test/resources/testdata/expectation/sar-without-dates.json
@@ -4,7 +4,8 @@
       "id": 1,
       "nomsId": "G1458GV",
       "creationDate": "2024-01-01T12:21:38.709",
-      "prisonId": null
+      "prisonId": null,
+      "legacyProfile": null
     },
     "assessment": {
       "id": 1,
@@ -23,7 +24,8 @@
         "id": 1,
         "nomsId": "G1458GV",
         "creationDate": "2024-01-01T12:21:38.709",
-        "prisonId": null
+        "prisonId": null,
+        "legacyProfile": null
       },
       "logs": [],
       "applicationSubmittedDate": "2023-08-16T12:21:38.709",


### PR DESCRIPTION
Added new column to prisoner
* set to null for existing prisoners
* set to false for new prisoners
* set to true when a pre-release report is submitted unless a new query parameter indicates that support needs is now live
* set to false on profile reset