### PR TITLE
RSP-1993: Add missing data to SAR report

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepository.kt
@@ -2,5 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
+import java.time.LocalDateTime
 
-interface AssessmentSkipRepository : JpaRepository<AssessmentSkipEntity, Long>
+interface AssessmentSkipRepository : JpaRepository<AssessmentSkipEntity, Long> {
+  fun findByPrisonerIdAndCreationDateBetween(prisonerId: Long, from: LocalDateTime, to: LocalDateTime): List<AssessmentSkipEntity>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/CaseAllocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/CaseAllocationRepository.kt
@@ -5,9 +5,12 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseAllocationCountResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseAllocationEntity
+import java.time.LocalDateTime
 
 @Repository
 interface CaseAllocationRepository : JpaRepository<CaseAllocationEntity, Long> {
+  fun findByPrisonerIdAndCreationDateBetween(prisonerId: Long, from: LocalDateTime, to: LocalDateTime): List<CaseAllocationEntity>
+
   fun findByPrisonerIdAndIsDeleted(prisonerId: Long, isDeleted: Boolean = false): CaseAllocationEntity?
 
   fun findByStaffIdAndIsDeleted(staffId: Int, isDeleted: Boolean = false): List<CaseAllocationEntity?>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/CaseNoteRetryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/CaseNoteRetryRepository.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseNoteRetryEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import java.time.LocalDateTime
 
 interface CaseNoteRetryRepository : JpaRepository<CaseNoteRetryEntity, Long> {
   fun findByNextRuntimeBeforeAndRetryCountLessThan(nextRuntime: LocalDateTime, retryCount: Int): List<CaseNoteRetryEntity>
+  fun findByPrisonerAndOriginalSubmissionDateBetween(prisoner: PrisonerEntity, from: LocalDateTime, to: LocalDateTime): List<CaseNoteRetryEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/DocumentsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/DocumentsRepository.kt
@@ -5,12 +5,15 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.DocumentCategory
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.DocumentsEntity
+import java.time.LocalDateTime
 
 @Repository
 interface DocumentsRepository : JpaRepository<DocumentsEntity, Long> {
   fun findAllByPrisonerId(prisonerId: Long): DocumentsEntity?
 
   fun findByPrisonerIdAndId(prisonerId: Long, documentId: Long): DocumentsEntity?
+
+  fun findAllByPrisonerIdAndCreationDateBetween(prisonerId: Long, from: LocalDateTime, to: LocalDateTime): List<DocumentsEntity>
 
   fun findAllByPrisonerIdAndCategoryOrderByCreationDateDesc(prisonerId: Long, category: DocumentCategory): List<DocumentsEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerSupportNeedRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerSupportNeedRepository.kt
@@ -5,10 +5,13 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedEntity
+import java.time.LocalDateTime
 
 @Repository
 interface PrisonerSupportNeedRepository : JpaRepository<PrisonerSupportNeedEntity, Long> {
   fun findAllByPrisonerIdAndDeletedIsFalse(prisonerId: Long): List<PrisonerSupportNeedEntity>
+
+  fun findAllByPrisonerIdAndCreatedDateBetween(prisonerId: Long, from: LocalDateTime, to: LocalDateTime): List<PrisonerSupportNeedEntity>
 
   fun findAllByPrisonerIdAndSupportNeedPathwayAndDeletedIsFalse(prisonerId: Long, pathway: Pathway): List<PrisonerSupportNeedEntity>
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerSupportNeedUpdateRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PrisonerSupportNeedUpdateRepository.kt
@@ -3,9 +3,11 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedUpdateEntity
+import java.time.LocalDateTime
 
 @Repository
 interface PrisonerSupportNeedUpdateRepository : JpaRepository<PrisonerSupportNeedUpdateEntity, Long> {
   fun findAllByPrisonerSupportNeedIdAndDeletedIsFalseOrderByCreatedDateDesc(id: Long): List<PrisonerSupportNeedUpdateEntity>
   fun findAllByPrisonerSupportNeedIdInAndDeletedIsFalse(ids: List<Long>): List<PrisonerSupportNeedUpdateEntity>
+  fun findAllByPrisonerSupportNeedIdInAndCreatedDateBetween(ids: List<Long>, from: LocalDateTime, to: LocalDateTime): List<PrisonerSupportNeedUpdateEntity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ProfileTagsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ProfileTagsRepository.kt
@@ -10,6 +10,8 @@ interface ProfileTagsRepository : JpaRepository<ProfileTagsEntity, Long> {
 
   fun findByPrisonerId(prisonerId: Long): ProfileTagsEntity
 
+  fun findAllByPrisonerId(prisonerId: Long): List<ProfileTagsEntity>
+
   fun findFirstByPrisonerId(prisonerId: Long): ProfileTagsEntity
 
   fun existsProfileTagsEntityByPrisonerId(prisonerId: Long): Boolean

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/TodoRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/TodoRepository.kt
@@ -6,11 +6,14 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.TodoEntity
+import java.time.LocalDateTime
 import java.util.*
 
 @Repository
 interface TodoRepository : JpaRepository<TodoEntity, Long> {
   fun findAllByPrisonerId(prisonerId: Long, sort: Sort = Sort.unsorted()): List<TodoEntity>
+
+  fun findAllByPrisonerIdAndCreationDateBetween(prisonerId: Long, from: LocalDateTime, to: LocalDateTime): List<TodoEntity>
 
   @Modifying
   @Query(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AssessmentService.kt
@@ -7,15 +7,19 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.NoDataWi
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ResourceNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Assessment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.AssessmentRepository
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.AssessmentSkipRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.IdTypeRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class AssessmentService(
   private val assessmentRepository: AssessmentRepository,
+  private val assessmentSkipRepository: AssessmentSkipRepository,
   private val prisonerRepository: PrisonerRepository,
   private val idTypeRepository: IdTypeRepository,
 ) {
@@ -41,7 +45,7 @@ class AssessmentService(
     val assessment = assessmentRepository.findByPrisonerIdAndIsDeletedAndCreationDateBetween(
       prisoner.id(),
       fromDate = fromDate.atStartOfDay(),
-      toDate = toDate.atStartOfDay(),
+      toDate = toDate.atTime(LocalTime.MAX),
     ) ?: throw ResourceNotFoundException("assessment not found")
     return if (assessment.isDeleted) null else assessment
   }
@@ -94,4 +98,6 @@ class AssessmentService(
     }
     deleteAssessment(assessment)
   }
+
+  fun findSkippedAssessmentsForPrisoner(prisonerId: Long, fromDate: LocalDate, toDate: LocalDate): List<AssessmentSkipEntity> = assessmentSkipRepository.findByPrisonerIdAndCreationDateBetween(prisonerId, fromDate.atStartOfDay(), toDate.atTime(LocalTime.MAX))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationService.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class BankApplicationService(
@@ -52,7 +53,7 @@ class BankApplicationService(
     val bankApplication = bankApplicationRepository.findByPrisonerIdAndIsDeletedAndCreationDateBetween(
       prisoner.id(),
       fromDate = fromDate.atStartOfDay(),
-      toDate = toDate.atStartOfDay(),
+      toDate = toDate.atTime(LocalTime.MAX),
     )
       ?: throw ResourceNotFoundException(" no none deleted bank applications for prisoner: ${prisoner.nomsId} found in database")
     return getBankApplicationResponse(bankApplication, prisoner)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationService.kt
@@ -15,7 +15,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.ManageUsersApiService
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.PrisonerSearchApiService
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class CaseAllocationService(
@@ -54,6 +56,12 @@ class CaseAllocationService(
 
   @Transactional
   fun getCaseAllocationByPrisonerId(prisonerId: Long): CaseAllocationEntity? = caseAllocationRepository.findByPrisonerIdAndIsDeleted(prisonerId, false)
+
+  fun getCaseAllocationHistoryByPrisonerId(prisonerId: Long, startDate: LocalDate, endDate: LocalDate): List<CaseAllocationEntity> {
+    val from = startDate.atStartOfDay()
+    val to = endDate.atTime(LocalTime.MAX)
+    return caseAllocationRepository.findByPrisonerIdAndCreationDateBetween(prisonerId, from, to)
+  }
 
   @Transactional
   fun delete(caseAllocation: CaseAllocationEntity): CaseAllocationEntity {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseNoteRetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseNoteRetryService.kt
@@ -5,9 +5,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseNoteRetryEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.CaseNoteRetryRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.ResettlementPassportDeliusApiService
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class CaseNoteRetryService(
@@ -48,6 +51,13 @@ class CaseNoteRetryService(
       log.warn("Retry failed for case note for ${caseNote.prisoner.nomsId} as no CRN found. Will schedule next retry.")
       scheduleNextRetry(caseNote)
     }
+  }
+
+  fun findByPrisoner(prisoner: PrisonerEntity, startDate: LocalDate, endDate: LocalDate): List<CaseNoteRetryEntity> {
+    val from = startDate.atStartOfDay()
+    val to = endDate.atTime(LocalTime.MAX)
+
+    return caseNoteRetryRepository.findByPrisonerAndOriginalSubmissionDateBetween(prisoner, from, to)
   }
 
   fun scheduleNextRetry(caseNote: CaseNoteRetryEntity) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DeliusContactService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DeliusContactService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class DeliusContactService(private val deliusContactRepository: DeliusContactRepository, private val prisonerRepository: PrisonerRepository) {
@@ -62,7 +63,7 @@ class DeliusContactService(private val deliusContactRepository: DeliusContactRep
       prisoner.id(),
       contactType,
       fromDate.atStartOfDay(),
-      toDate.atStartOfDay(),
+      toDate.atTime(LocalTime.MAX),
     )
     return mapDeliusContactsToPathwayCaseNotes(deliusContacts)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentService.kt
@@ -22,7 +22,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.VirusScanResult.NoVirusFound
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.VirusScanResult.VirusFound
 import java.io.InputStream
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.UUID
 
 private val logger = KotlinLogging.logger {}
@@ -152,6 +154,12 @@ class DocumentService(
     documentsRepository.findAllByNomsId(nomsId)
   } else {
     documentsRepository.findAllByNomsIdAndCategory(nomsId, category)
+  }
+
+  fun listDocuments(prisonerId: Long, startDate: LocalDate, endDate: LocalDate): List<DocumentsEntity> {
+    val from = startDate.atStartOfDay()
+    val to = endDate.atTime(LocalTime.MAX)
+    return documentsRepository.findAllByPrisonerIdAndCreationDateBetween(prisonerId, from, to)
   }
 
   fun deleteUploadDocumentByNomisId(nomsId: String, category: DocumentCategory) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/IdApplicationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/IdApplicationService.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class IdApplicationService(
@@ -32,7 +33,7 @@ class IdApplicationService(
     val idApplicationEntityList = idApplicationRepository.findByPrisonerIdAndIsDeletedAndCreationDateBetween(
       prisoner.id(),
       fromDate = fromDate.atStartOfDay(),
-      toDate = toDate.atStartOfDay(),
+      toDate = toDate.atTime(LocalTime.MAX),
     )
     if (idApplicationEntityList.isEmpty()) {
       throw ResourceNotFoundException("No active ID application found for prisoner with id $nomsId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentService.kt
@@ -41,6 +41,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettl
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies.processProfileTags
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class ResettlementAssessmentService(
@@ -81,7 +82,7 @@ class ResettlementAssessmentService(
       prisonerEntity.id(),
       assessmentType,
       fromDate.atStartOfDay(),
-      toDate.atStartOfDay(),
+      toDate.atTime(LocalTime.MAX),
     )
     return getAssessmentSummary(resettlementEntityList)
   }
@@ -403,7 +404,7 @@ class ResettlementAssessmentService(
         pathway,
         ResettlementAssessmentStatus.SUBMITTED,
         fromDate.atStartOfDay(),
-        toDate.atStartOfDay(),
+        toDate.atTime(LocalTime.MAX),
       )
         ?: throw ResourceNotFoundException("No submitted resettlement assessment found for prisoner $nomsId / pathway $pathway"),
       resettlementAssessmentStrategies,
@@ -548,4 +549,6 @@ class ResettlementAssessmentService(
 
   fun getLastReportToNomsIdByPrisonId(prisonId: String) = resettlementAssessmentRepository.findLastReportByPrison(prisonId)
     .associate { it.nomsId to LastReport(type = it.assessmentType, dateCompleted = if (it.submissionDate != null) it.submissionDate!!.toLocalDate() else it.createdDate.toLocalDate()) }
+
+  fun getProfileTagsByPrisonerId(prisonerId: Long) = profileTagsRepository.findAllByPrisonerId(prisonerId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SubjectAccessRequestService.kt
@@ -8,9 +8,18 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PathwayCas
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.LatestResettlementAssessmentResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.PrisonerResettlementAssessment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseAllocationEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseNoteRetryEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.DocumentsEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.IdApplicationEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PathwayStatusEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedUpdateEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagsEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.TodoEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies.ResettlementAssessmentStrategy
 import uk.gov.justice.hmpps.kotlin.sar.HmppsPrisonSubjectAccessRequestService
@@ -24,8 +33,14 @@ class SubjectAccessRequestService(
   private val bankApplicationService: BankApplicationService,
   private val deliusContactService: DeliusContactService,
   private val idApplicationService: IdApplicationService,
+  private val pathwayAndStatusService: PathwayAndStatusService,
   private val resettlementAssessmentService: ResettlementAssessmentService,
   private val resettlementAssessmentStrategies: ResettlementAssessmentStrategy,
+  private val supportNeedsService: SupportNeedsService,
+  private val caseAllocationService: CaseAllocationService,
+  private val todoService: TodoService,
+  private val caseNoteRetryService: CaseNoteRetryService,
+  private val documentService: DocumentService,
 ) : HmppsPrisonSubjectAccessRequestService {
 
   override fun getPrisonContentFor(
@@ -39,22 +54,41 @@ class SubjectAccessRequestService(
 
     val prisonerEntity = prisonerRepository.findByNomsId(prn)
       ?: throw NoContentException("Prisoner with id $prn not found in database")
+    val prisonerId = prisonerEntity.id!!
 
     val assessmentData = getAssessment(prn, startDate, endDate)
+    val skippedAssessments = assessmentService.findSkippedAssessmentsForPrisoner(prisonerId, startDate, endDate)
     val bankApplicationData = getBankAccount(prn, startDate, endDate)
     val deliusContactData = getDeliusContact(prn, startDate, endDate)
     val idApplicationData = getId(prn, startDate, endDate)
+    val pathwayStatus = pathwayAndStatusService.findAllPathwayStatusForPrisoner(prisonerEntity)
     val resettlementAssessmentsPathwayStatus = getPathwayStatus(prn, startDate, endDate)
     val resettlementAssessments = getResettlementAssessments(prn, startDate, endDate)
+    val supportNeeds = supportNeedsService.getAllSupportNeedsForPrisoner(prisonerId, startDate, endDate)
+    val supportNeedUpdates = supportNeedsService.getAllSupportNeedUpdatesForPrisoner(supportNeeds, startDate, endDate)
+    val caseAllocation = caseAllocationService.getCaseAllocationHistoryByPrisonerId(prisonerId, startDate, endDate)
+    val profileTags = resettlementAssessmentService.getProfileTagsByPrisonerId(prisonerId)
+    val todoItems = todoService.getByPrisonerId(prisonerId, startDate, endDate)
+    val caseNotes = caseNoteRetryService.findByPrisoner(prisonerEntity, startDate, endDate)
+    val documents = documentService.listDocuments(prisonerId, startDate, endDate)
 
     val resettlementData = ResettlementSarContent(
       prisonerEntity,
       assessmentData,
+      skippedAssessments,
       bankApplicationData,
       deliusContactData,
       idApplicationData,
+      pathwayStatus,
       resettlementAssessmentsPathwayStatus,
       resettlementAssessments,
+      supportNeeds,
+      supportNeedUpdates,
+      caseAllocation,
+      profileTags,
+      todoItems,
+      caseNotes,
+      documents,
     )
     return HmppsSubjectAccessRequestContent(
       content = resettlementData,
@@ -115,11 +149,20 @@ class SubjectAccessRequestService(
 data class ResettlementSarContent(
   val prisoner: PrisonerEntity?,
   val assessment: AssessmentEntity?,
+  val skippedAssessments: List<AssessmentSkipEntity>?,
   val bankApplication: BankApplicationResponse?,
   val deliusContact: List<PathwayCaseNote>?,
   val idApplication: IdApplicationEntity?,
+  val pathwayStatus: List<PathwayStatusEntity>?,
   val statusSummary: List<ResettlementAssessmentPathwayStatus>?,
   val resettlementAssessment: List<LatestResettlementAssessmentResponse>?,
+  val supportNeeds: List<PrisonerSupportNeedEntity>?,
+  val supportNeedUpdates: List<PrisonerSupportNeedUpdateEntity>?,
+  val caseAllocation: List<CaseAllocationEntity>?,
+  val profileTags: List<ProfileTagsEntity>?,
+  val todoItems: List<TodoEntity>?,
+  val caseNotes: List<CaseNoteRetryEntity>?,
+  val documents: Collection<DocumentsEntity>?,
 )
 
 data class ResettlementAssessmentPathwayStatus(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsService.kt
@@ -31,7 +31,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.SupportNeedRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.CaseNotesApiService
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.PrisonerSearchApiService
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Service
 class SupportNeedsService(
@@ -488,5 +490,18 @@ class SupportNeedsService(
     }
 
     prisonerSupportNeedUpdateRepository.saveAll(profileResetUpdates)
+  }
+
+  fun getAllSupportNeedsForPrisoner(prisonerId: Long, startDate: LocalDate, endDate: LocalDate): List<PrisonerSupportNeedEntity> {
+    val from = startDate.atStartOfDay()
+    val to = endDate.atTime(LocalTime.MAX)
+
+    return prisonerSupportNeedRepository.findAllByPrisonerIdAndCreatedDateBetween(prisonerId, from, to)
+  }
+  fun getAllSupportNeedUpdatesForPrisoner(supportNeeds: List<PrisonerSupportNeedEntity>, startDate: LocalDate, endDate: LocalDate): List<PrisonerSupportNeedUpdateEntity> {
+    val from = startDate.atStartOfDay()
+    val to = endDate.atTime(LocalTime.MAX)
+
+    return prisonerSupportNeedUpdateRepository.findAllByPrisonerSupportNeedIdInAndCreatedDateBetween(supportNeeds.mapNotNull { it.id }, from, to)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/TodoService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/TodoService.kt
@@ -12,7 +12,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.TodoRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.resource.TodoPatchRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.resource.TodoRequest
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.*
 import kotlin.reflect.full.declaredMemberProperties
 
@@ -35,6 +37,8 @@ class TodoService(
     return todoRepository.findByIdAndPrisonerId(id, prisonerRecord.id())
       ?: throw ResourceNotFoundException("No item found for $id")
   }
+
+  fun getByPrisonerId(prisonerId: Long, from: LocalDate, to: LocalDate): List<TodoEntity> = todoRepository.findAllByPrisonerIdAndCreationDateBetween(prisonerId, from.atStartOfDay(), to.atTime(LocalTime.MAX))
 
   fun getList(nomsId: String, sortField: String? = null, sortDirection: Sort.Direction? = null): List<TodoEntity> {
     val sort = if (sortField != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/AssessmentSkipRepositoryTest.kt
@@ -1,0 +1,83 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.AssessmentSkipReason
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
+import java.time.LocalDateTime
+
+class AssessmentSkipRepositoryTest : RepositoryTestBase() {
+  @Autowired
+  lateinit var assessmentSkipRepository: AssessmentSkipRepository
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
+  var prisonerId: Long = 0L
+  var skippedAssessment: AssessmentSkipEntity? = null
+
+  @BeforeEach
+  fun beforeEach() {
+    val prisoner = PrisonerEntity(null, "NOM1234", LocalDateTime.now(), "xyz1")
+    prisonerRepository.save(prisoner)
+    prisonerId = prisoner.id()
+
+    skippedAssessment = AssessmentSkipEntity(
+      null,
+      ResettlementAssessmentType.BCST2,
+      prisoner.id(),
+      AssessmentSkipReason.OTHER,
+      "More info",
+      "Admin user",
+    )
+    assessmentSkipRepository.save(skippedAssessment!!)
+  }
+
+  @Test
+  fun `should persist new skipped assessment`() {
+    val result = assessmentSkipRepository.findAll()[0]
+    Assertions.assertEquals(skippedAssessment, result)
+  }
+
+  @Nested
+  inner class FindByPrisonerIdAndCreationDateBetween {
+
+    @Test
+    fun `should return results within time range`() {
+      val createdDate = skippedAssessment?.creationDate!!
+      val result = assessmentSkipRepository.findByPrisonerIdAndCreationDateBetween(
+        prisonerId,
+        createdDate.minusDays(1),
+        createdDate.plusDays(1),
+      )
+      Assertions.assertEquals(listOf(skippedAssessment), result)
+    }
+
+    @Test
+    fun `should not return results outside of time range`() {
+      val createdDate = skippedAssessment?.creationDate!!
+      val result = assessmentSkipRepository.findByPrisonerIdAndCreationDateBetween(
+        prisonerId,
+        createdDate.minusDays(2),
+        createdDate.minusDays(1),
+      )
+      Assertions.assertEquals(listOf<AssessmentSkipEntity>(), result)
+    }
+
+    @Test
+    fun `should not return results if we don't match the prisoner id`() {
+      val createdDate = skippedAssessment?.creationDate!!
+      val result = assessmentSkipRepository.findByPrisonerIdAndCreationDateBetween(
+        prisonerId + 1,
+        createdDate.minusDays(1),
+        createdDate.plusDays(1),
+      )
+      Assertions.assertEquals(listOf<AssessmentSkipEntity>(), result)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/DocumentsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/DocumentsRepositoryTest.kt
@@ -1,0 +1,72 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.DocumentCategory
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.DocumentsEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import java.time.LocalDateTime
+import java.util.*
+
+class DocumentsRepositoryTest : RepositoryTestBase() {
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
+  @Autowired
+  lateinit var documentsRepository: DocumentsRepository
+
+  @Test
+  fun `test findAllByPrisonerIdAndCreationDateBetween query`() {
+    // Seed database with prisoners and documents
+    val prisoner1 = prisonerRepository.save(PrisonerEntity(null, "NOMS1", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+    val prisoner2 = prisonerRepository.save(PrisonerEntity(null, "NOMS2", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+
+    val searchDate = LocalDateTime.now()
+
+    val todoItems = listOf(
+      DocumentsEntity(
+        id = null,
+        prisonerId = prisoner2.id(),
+        originalDocumentKey = UUID.randomUUID(),
+        pdfDocumentKey = UUID.randomUUID(),
+        creationDate = searchDate.minusDays(10),
+        category = DocumentCategory.LICENCE_CONDITIONS,
+        originalDocumentFileName = "license1.pdf",
+        isDeleted = true,
+        deletionDate = searchDate.minusDays(1),
+      ),
+      DocumentsEntity(
+        id = null,
+        prisonerId = prisoner2.id(),
+        originalDocumentKey = UUID.randomUUID(),
+        pdfDocumentKey = UUID.randomUUID(),
+        creationDate = searchDate.minusDays(5),
+        category = DocumentCategory.LICENCE_CONDITIONS,
+        originalDocumentFileName = "license2.pdf",
+        isDeleted = true,
+        deletionDate = searchDate.minusDays(1),
+      ),
+      DocumentsEntity(
+        id = null,
+        prisonerId = prisoner2.id(),
+        originalDocumentKey = UUID.randomUUID(),
+        pdfDocumentKey = UUID.randomUUID(),
+        creationDate = searchDate,
+        category = DocumentCategory.LICENCE_CONDITIONS,
+        originalDocumentFileName = "license3.pdf",
+        isDeleted = false,
+        deletionDate = null,
+      ),
+    )
+
+    documentsRepository.saveAll(todoItems)
+
+    // Prisoner 1 has documents
+    Assertions.assertThat(documentsRepository.findAllByPrisonerIdAndCreationDateBetween(prisoner1.id(), searchDate.minusDays(7), searchDate.plusDays(1))).isEmpty()
+
+    // Prisoner 2 has three - one is out of search range
+    Assertions.assertThat(documentsRepository.findAllByPrisonerIdAndCreationDateBetween(prisoner2.id(), searchDate.minusDays(7), searchDate.plusDays(1))).isEqualTo(todoItems.filter { it.creationDate > searchDate.minusDays(7) })
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PathwayStatusRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/PathwayStatusRepositoryTest.kt
@@ -85,4 +85,28 @@ class PathwayStatusRepositoryTest : RepositoryTestBase() {
           pathwayStatusesPrisoner3.map { Tuple(it.prisonerId, it.pathway, it.status) },
       )
   }
+
+  @Test
+  fun `test findByPrisonerId query`() {
+    // Seed database with prisoners and pathway statuses
+    val prisoner1 = prisonerRepository.save(PrisonerEntity(null, "NOMS1", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+    val prisoner2 = prisonerRepository.save(PrisonerEntity(null, "NOMS2", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+
+    val pathwayStatuses = listOf(
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.ACCOMMODATION, Status.NOT_STARTED, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, Status.SUPPORT_NOT_REQUIRED, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, Status.SUPPORT_DECLINED, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.DRUGS_AND_ALCOHOL, Status.IN_PROGRESS, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.EDUCATION_SKILLS_AND_WORK, Status.DONE, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.FINANCE_AND_ID, Status.NOT_STARTED, LocalDateTime.parse("2023-09-12T12:34:56")),
+      PathwayStatusEntity(null, prisoner2.id(), Pathway.HEALTH, Status.DONE, LocalDateTime.parse("2023-09-12T12:34:56")),
+    )
+
+    pathwayStatusRepository.saveAll(pathwayStatuses)
+
+    // Prisoner 1 has no pathway statuses
+    // Prisoner 2 has all pathways set
+    assertThat(pathwayStatusRepository.findByPrisonerId(prisoner1.id())).isEmpty()
+    assertThat(pathwayStatusRepository.findByPrisonerId(prisoner2.id())).isEqualTo(pathwayStatuses)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ProfileTagsRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/ProfileTagsRepositoryTest.kt
@@ -1,0 +1,47 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagList
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagsEntity
+import java.time.LocalDateTime
+
+class ProfileTagsRepositoryTest : RepositoryTestBase() {
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
+  @Autowired
+  lateinit var profileTagsRepository: ProfileTagsRepository
+
+  @Test
+  fun `test findAllByPrisonerId query`() {
+    // Seed database with prisoners and profile tags
+    val prisoner1 = prisonerRepository.save(PrisonerEntity(null, "NOMS1", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+    val prisoner2 = prisonerRepository.save(PrisonerEntity(null, "NOMS2", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+
+    val profileTags = listOf(
+      ProfileTagsEntity(
+        id = null,
+        prisonerId = prisoner2.id(),
+        profileTags = ProfileTagList(listOf("tag 1", "tag 2")),
+        updatedDate = LocalDateTime.now(),
+      ),
+      ProfileTagsEntity(
+        id = null,
+        prisonerId = prisoner2.id(),
+        profileTags = ProfileTagList(listOf("tag 3", "tag 4")),
+        updatedDate = LocalDateTime.now(),
+      ),
+    )
+
+    profileTagsRepository.saveAll(profileTags)
+
+    // Prisoner 1 has no profile tags
+    // Prisoner 2 has profile tags
+    Assertions.assertThat(profileTagsRepository.findAllByPrisonerId(prisoner1.id())).isEmpty()
+    Assertions.assertThat(profileTagsRepository.findAllByPrisonerId(prisoner2.id())).isEqualTo(profileTags)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/TodoRepositoryTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/repository/TodoRepositoryTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository
+
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.TodoEntity
+import java.time.LocalDateTime
+import java.util.*
+
+class TodoRepositoryTest : RepositoryTestBase() {
+
+  @Autowired
+  lateinit var prisonerRepository: PrisonerRepository
+
+  @Autowired
+  lateinit var todoRepository: TodoRepository
+
+  @Test
+  fun `test findByPrisonerId query`() {
+    // Seed database with prisoners and to do items
+    val prisoner1 = prisonerRepository.save(PrisonerEntity(null, "NOMS1", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+    val prisoner2 = prisonerRepository.save(PrisonerEntity(null, "NOMS2", LocalDateTime.parse("2023-12-13T12:00:00"), "MDI"))
+
+    val searchDate = LocalDateTime.now()
+
+    val todoItems = listOf(
+      TodoEntity(
+        id = UUID.randomUUID(),
+        prisonerId = prisoner2.id(),
+        title = "note 1",
+        notes = null,
+        dueDate = null,
+        completed = false,
+        createdByUrn = "urn",
+        updatedByUrn = "urn",
+        creationDate = searchDate.minusDays(10),
+      ),
+      TodoEntity(
+        id = UUID.randomUUID(),
+        prisonerId = prisoner2.id(),
+        title = "note 2",
+        notes = null,
+        dueDate = null,
+        completed = false,
+        createdByUrn = "urn",
+        updatedByUrn = "urn",
+        creationDate = searchDate.minusDays(5),
+      ),
+      TodoEntity(
+        id = UUID.randomUUID(),
+        prisonerId = prisoner2.id(),
+        title = "note 3",
+        notes = null,
+        dueDate = null,
+        completed = false,
+        createdByUrn = "urn",
+        updatedByUrn = "urn",
+        creationDate = searchDate,
+      ),
+    )
+
+    todoRepository.saveAll(todoItems)
+
+    // Prisoner 1 has no to do items
+    // Prisoner 2 has three - one is out of search range
+    Assertions.assertThat(todoRepository.findAllByPrisonerIdAndCreationDateBetween(prisoner1.id(), searchDate.minusDays(7), searchDate.plusDays(1))).isEmpty()
+    Assertions.assertThat(todoRepository.findAllByPrisonerIdAndCreationDateBetween(prisoner2.id(), searchDate.minusDays(7), searchDate.plusDays(1))).isEqualTo(todoItems.filter { it.creationDate > searchDate.minusDays(7) })
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/DocumentServiceTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 import dev.forkhandles.result4k.valueOrNull
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -23,7 +24,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Docu
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.DocumentsRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.util.*
 
 @ExtendWith(MockitoExtension::class)
@@ -160,5 +163,41 @@ class DocumentServiceTest {
     documentsEntity.isDeleted = true
     documentsEntity.deletionDate = fakeNow
     Mockito.verify(documentsRepository).save(documentsEntity)
+  }
+
+  @Nested
+  inner class ListDocuments {
+    private val toDate = LocalDate.of(2025, 4, 11)
+    private val fromDate = toDate.minusDays(7)
+
+    @Test
+    fun `should search between the start of fromDate and the end of toDate`() {
+      Mockito.`when`(documentsRepository.findAllByPrisonerIdAndCreationDateBetween(any(), any(), any())).thenReturn(null)
+
+      documentService.listDocuments(1, fromDate, toDate)
+      Mockito.verify(documentsRepository).findAllByPrisonerIdAndCreationDateBetween(1, fromDate.atStartOfDay(), toDate.atTime(LocalTime.MAX))
+    }
+
+    @Test
+    fun `should return data from repository`() {
+      val data = listOf(
+        DocumentsEntity(
+          id = null,
+          prisonerId = 1,
+          originalDocumentKey = UUID.randomUUID(),
+          pdfDocumentKey = UUID.randomUUID(),
+          creationDate = toDate.minusDays(5).atTime(LocalTime.NOON),
+          category = DocumentCategory.LICENCE_CONDITIONS,
+          originalDocumentFileName = "license2.pdf",
+          isDeleted = false,
+          deletionDate = null,
+        ),
+      )
+
+      Mockito.`when`(documentsRepository.findAllByPrisonerIdAndCreationDateBetween(any(), any(), any())).thenReturn(data)
+
+      val response = documentService.listDocuments(1, fromDate, toDate)
+      Assertions.assertEquals(data, response)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusServiceTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.springframework.http.HttpStatusCode
 import org.springframework.transaction.support.TransactionOperations
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ResourceNotFoundException
@@ -98,5 +99,16 @@ class PathwayAndStatusServiceTest {
 
     assertThrows<ResourceNotFoundException> { pathwayAndStatusService.updatePathwayStatus(nomsId, PathwayAndStatus(pathway, newStatus)) }
     Mockito.verify(pathwayStatusRepository, Mockito.never()).save(Mockito.any())
+  }
+
+  @Test
+  fun `test findAllPathwayStatusForPrisoner - should return result from repository`() {
+    val prisonerEntity = PrisonerEntity(1, "nomsId", testDate, "prisonId")
+    val pathwayData = PathwayStatusEntity(1, prisonerEntity.id(), Pathway.ACCOMMODATION, Status.NOT_STARTED, LocalDateTime.now())
+    Mockito.`when`(pathwayStatusRepository.findByPrisonerId(any())).thenReturn(listOf(pathwayData))
+
+    val result = pathwayAndStatusService.findAllPathwayStatusForPrisoner(prisonerEntity)
+
+    Assertions.assertEquals(listOf(pathwayData), result)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
@@ -19,6 +19,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
@@ -43,6 +44,8 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettleme
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentSubmitResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagList
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagsEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
@@ -1024,4 +1027,14 @@ class ResettlementAssessmentServiceTest {
       View finance and ID report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/finance-and-id/?prisonerNumber=A123&fromDelius=true#assessment-information
       View health report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/health-status/?prisonerNumber=A123&fromDelius=true#assessment-information
     """.trimIndent()
+
+  @Test
+  fun `test getProfileTagsByPrisonerId`() {
+    val data = listOf(ProfileTagsEntity(null, 1, ProfileTagList(listOf("tag 1", "tag 2")), null))
+    Mockito.`when`(profileTagsRepository.findAllByPrisonerId(any())).thenReturn(data)
+
+    val result = resettlementAssessmentService.getProfileTagsByPrisonerId(1)
+
+    Assertions.assertEquals(data, result)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/TodoServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/TodoServiceTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.Mockito
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.TodoEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.TodoRepository
+import java.time.LocalDate
+import java.time.LocalTime
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+class TodoServiceTest {
+
+  private lateinit var todoService: TodoService
+
+  @Mock
+  private lateinit var todoRepository: TodoRepository
+
+  @Mock
+  private lateinit var prisonerRepository: PrisonerRepository
+
+  @BeforeEach
+  fun beforeEach() {
+    todoService = TodoService(todoRepository, prisonerRepository)
+  }
+
+  @Nested
+  inner class GetByPrisonerId {
+    private val toDate = LocalDate.of(2025, 4, 11)
+    private val fromDate = toDate.minusDays(7)
+
+    @Test
+    fun `should search between the start of fromDate and the end of toDate`() {
+      Mockito.`when`(todoRepository.findAllByPrisonerIdAndCreationDateBetween(any(), any(), any())).thenReturn(null)
+
+      todoService.getByPrisonerId(1, fromDate, toDate)
+      Mockito.verify(todoRepository).findAllByPrisonerIdAndCreationDateBetween(1, fromDate.atStartOfDay(), toDate.atTime(LocalTime.MAX))
+    }
+
+    @Test
+    fun `should return data from repository`() {
+      val data = listOf(
+        TodoEntity(
+          id = UUID.randomUUID(),
+          prisonerId = 1,
+          title = "title",
+          notes = null,
+          dueDate = null,
+          completed = false,
+          createdByUrn = "urn",
+          updatedByUrn = "urn",
+          creationDate = toDate.atStartOfDay(),
+        ),
+      )
+
+      Mockito.`when`(todoRepository.findAllByPrisonerIdAndCreationDateBetween(any(), any(), any())).thenReturn(data)
+
+      val response = todoService.getByPrisonerId(1, fromDate, toDate)
+      Assertions.assertEquals(data, response)
+    }
+  }
+}

--- a/src/test/resources/testdata/expectation/sar-with-dates-1.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-1.json
@@ -8,6 +8,17 @@
       "supportNeedsLegacyProfile": null
     },
     "assessment": null,
+    "skippedAssessments":  [
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2023-09-01T12:00:00",
+        "id": 3,
+        "moreInfo": "Skipped for other reason",
+        "prisonerId": 1,
+        "reason": "OTHER"
+      }
+    ],
     "bankApplication": null,
     "deliusContact": [
       {
@@ -20,6 +31,57 @@
       }
     ],
     "idApplication": null,
+    "pathwayStatus": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "pathway": "ACCOMMODATION",
+        "status": "NOT_STARTED",
+        "updatedDate": "2023-08-16T12:21:44.234"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "pathway": "ATTITUDES_THINKING_AND_BEHAVIOUR",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.466"
+      },
+      {
+        "id": 3,
+        "prisonerId": 1,
+        "pathway": "CHILDREN_FAMILIES_AND_COMMUNITY",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.475"
+      },
+      {
+        "id": 4,
+        "prisonerId": 1,
+        "pathway": "DRUGS_AND_ALCOHOL",
+        "status": "SUPPORT_DECLINED",
+        "updatedDate": "2023-08-17T12:28:10.479"
+      },
+      {
+        "id": 5,
+        "prisonerId": 1,
+        "pathway": "EDUCATION_SKILLS_AND_WORK",
+        "status": "DONE",
+        "updatedDate": "2023-08-17T12:28:10.483"
+      },
+      {
+        "id": 6,
+        "prisonerId": 1,
+        "pathway": "FINANCE_AND_ID",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.49"
+      },
+      {
+        "id": 7,
+        "prisonerId": 1,
+        "pathway": "HEALTH",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.493"
+      }
+    ],
     "statusSummary": [
       {
         "type": "BCST2",
@@ -495,6 +557,134 @@
             }
           ]
         }
+      }
+    ],
+    "supportNeeds": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T12:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 3,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      }
+    ],
+    "supportNeedUpdates": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 4,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "MET",
+        "updateText": "Support need met"
+      }
+    ],
+    "caseAllocation": [
+      {
+        "creationDate": "2023-09-01T12:00:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      }
+    ],
+    "profileTags": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      }
+    ],
+    "todoItems": [
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2023-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "796e405b-2b56-4ba8-a237-15f2151bb1b0",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2023-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      }
+    ],
+    "caseNotes": [
+      {
+        "author": "Matthew Kerry",
+        "id": 3,
+        "nextRuntime": "2023-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2023-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      }
+    ],
+    "documents": [
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2023-09-01T12:01:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "originalDocumentFileName": "license3.pdf",
+        "originalDocumentKey": "10ad790a-6981-4b9c-bace-604c0468ec5b",
+        "pdfDocumentKey": "ed25e653-607f-428b-9c0d-06cc67465fb7",
+        "prisonerId": 1
       }
     ]
   }

--- a/src/test/resources/testdata/expectation/sar-with-dates-2.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-2.json
@@ -18,6 +18,26 @@
       "isDeleted": false,
       "deletionDate": null
     },
+    "skippedAssessments":  [
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2022-09-01T12:00:00",
+        "id": 2,
+        "moreInfo": "Skipped as on early release",
+        "prisonerId": 1,
+        "reason": "EARLY_RELEASE"
+      },
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2023-09-01T12:00:00",
+        "id": 3,
+        "moreInfo": "Skipped for other reason",
+        "prisonerId": 1,
+        "reason": "OTHER"
+      }
+    ],
     "bankApplication": {
       "id": 1,
       "prisoner": {
@@ -80,6 +100,57 @@
       "deletionDate": null,
       "dateIdReceived": null
     },
+    "pathwayStatus": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "pathway": "ACCOMMODATION",
+        "status": "NOT_STARTED",
+        "updatedDate": "2023-08-16T12:21:44.234"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "pathway": "ATTITUDES_THINKING_AND_BEHAVIOUR",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.466"
+      },
+      {
+        "id": 3,
+        "prisonerId": 1,
+        "pathway": "CHILDREN_FAMILIES_AND_COMMUNITY",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.475"
+      },
+      {
+        "id": 4,
+        "prisonerId": 1,
+        "pathway": "DRUGS_AND_ALCOHOL",
+        "status": "SUPPORT_DECLINED",
+        "updatedDate": "2023-08-17T12:28:10.479"
+      },
+      {
+        "id": 5,
+        "prisonerId": 1,
+        "pathway": "EDUCATION_SKILLS_AND_WORK",
+        "status": "DONE",
+        "updatedDate": "2023-08-17T12:28:10.483"
+      },
+      {
+        "id": 6,
+        "prisonerId": 1,
+        "pathway": "FINANCE_AND_ID",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.49"
+      },
+      {
+        "id": 7,
+        "prisonerId": 1,
+        "pathway": "HEALTH",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.493"
+      }
+    ],
     "statusSummary": [
       {
         "type": "BCST2",
@@ -555,6 +626,218 @@
             }
           ]
         }
+      }
+    ],
+    "supportNeeds": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2022-09-01T12:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 2,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T12:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 3,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      }
+    ],
+    "supportNeedUpdates": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2022-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 3,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "IN_PROGRESS",
+        "updateText": "Support need in progress 3"
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 4,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "MET",
+        "updateText": "Support need met"
+      }
+    ],
+    "caseAllocation": [
+      {
+        "creationDate": "2022-09-01T12:00:00",
+        "deletionDate": "2022-09-02T12:00:00",
+        "id": 2,
+        "isDeleted": true,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      },
+      {
+        "creationDate": "2023-09-01T12:00:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      }
+    ],
+    "profileTags": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      }
+    ],
+    "todoItems": [
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2022-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "48b6d8c4-be42-492e-bebc-71d4e396676d",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2022-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      },
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2023-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "796e405b-2b56-4ba8-a237-15f2151bb1b0",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2023-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      }
+    ],
+    "caseNotes": [
+      {
+        "author": "Matthew Kerry",
+        "id": 2,
+        "nextRuntime": "2022-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2022-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      },
+      {
+        "author": "Matthew Kerry",
+        "id": 3,
+        "nextRuntime": "2023-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2023-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      }
+    ],
+    "documents": [
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2022-09-01T12:01:00",
+        "deletionDate": "2022-09-02T12:01:00",
+        "id": 2,
+        "isDeleted": true,
+        "originalDocumentFileName": "license2.pdf",
+        "originalDocumentKey": "3e5a4c5b-86d8-4617-bfbe-15aa3a91dfd3",
+        "pdfDocumentKey": "32deeb98-30f4-4baa-b187-1b0276736797",
+        "prisonerId": 1
+      },
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2023-09-01T12:01:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "originalDocumentFileName": "license3.pdf",
+        "originalDocumentKey": "10ad790a-6981-4b9c-bace-604c0468ec5b",
+        "pdfDocumentKey": "ed25e653-607f-428b-9c0d-06cc67465fb7",
+        "prisonerId": 1
       }
     ]
   }

--- a/src/test/resources/testdata/expectation/sar-without-dates.json
+++ b/src/test/resources/testdata/expectation/sar-without-dates.json
@@ -18,6 +18,35 @@
       "isDeleted": false,
       "deletionDate": null
     },
+    "skippedAssessments": [
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2020-09-01T12:00:00",
+        "id": 1,
+        "moreInfo": "Skipped as completed in OASys",
+        "prisonerId": 1,
+        "reason": "COMPLETED_IN_OASYS"
+      },
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2022-09-01T12:00:00",
+        "id": 2,
+        "moreInfo": "Skipped as on early release",
+        "prisonerId": 1,
+        "reason": "EARLY_RELEASE"
+      },
+      {
+        "assessmentType": "BCST2",
+        "createdBy": "MKERRY_GEN",
+        "creationDate": "2023-09-01T12:00:00",
+        "id": 3,
+        "moreInfo": "Skipped for other reason",
+        "prisonerId": 1,
+        "reason": "OTHER"
+      }
+    ],
     "bankApplication": {
       "id": 1,
       "prisoner": {
@@ -80,6 +109,57 @@
       "deletionDate": null,
       "dateIdReceived": null
     },
+    "pathwayStatus": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "pathway": "ACCOMMODATION",
+        "status": "NOT_STARTED",
+        "updatedDate": "2023-08-16T12:21:44.234"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "pathway": "ATTITUDES_THINKING_AND_BEHAVIOUR",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.466"
+      },
+      {
+        "id": 3,
+        "prisonerId": 1,
+        "pathway": "CHILDREN_FAMILIES_AND_COMMUNITY",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.475"
+      },
+      {
+        "id": 4,
+        "prisonerId": 1,
+        "pathway": "DRUGS_AND_ALCOHOL",
+        "status": "SUPPORT_DECLINED",
+        "updatedDate": "2023-08-17T12:28:10.479"
+      },
+      {
+        "id": 5,
+        "prisonerId": 1,
+        "pathway": "EDUCATION_SKILLS_AND_WORK",
+        "status": "DONE",
+        "updatedDate": "2023-08-17T12:28:10.483"
+      },
+      {
+        "id": 6,
+        "prisonerId": 1,
+        "pathway": "FINANCE_AND_ID",
+        "status": "IN_PROGRESS",
+        "updatedDate": "2023-08-17T12:28:10.49"
+      },
+      {
+        "id": 7,
+        "prisonerId": 1,
+        "pathway": "HEALTH",
+        "status": "SUPPORT_NOT_REQUIRED",
+        "updatedDate": "2023-08-17T12:28:10.493"
+      }
+    ],
     "statusSummary": [
       {
         "type": "BCST2",
@@ -555,6 +635,314 @@
             }
           ]
         }
+      }
+    ],
+    "supportNeeds": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2020-09-01T12:00:00",
+        "deleted": true,
+        "deletedDate": "2023-09-01T12:00:00",
+        "id": 1,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2022-09-01T12:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 2,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T12:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 3,
+        "latestUpdateId": null,
+        "otherDetail": null,
+        "prisonerId": 1,
+        "supportNeed": {
+          "allowOtherDetail": false,
+          "createdDate": "2020-01-01T00:00:00",
+          "deleted": false,
+          "deletedDate": null,
+          "excludeFromCount": false,
+          "hidden": false,
+          "id": 999999,
+          "pathway": "ACCOMMODATION",
+          "section": "Test support need",
+          "title": "Used for exact creation date"
+        }
+      }
+    ],
+    "supportNeedUpdates": [
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2020-09-01T12:00:00",
+        "deleted": true,
+        "deletedDate": "2020-09-01T13:00:00",
+        "id": 1,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "IN_PROGRESS",
+        "updateText": "Support need in progress 1"
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2020-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 2,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "IN_PROGRESS",
+        "updateText": "Support need in progress 2"
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2022-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 3,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "IN_PROGRESS",
+        "updateText": "Support need in progress 3"
+      },
+      {
+        "createdBy": "Matthew Kerry",
+        "createdDate": "2023-09-01T14:00:00",
+        "deleted": false,
+        "deletedDate": null,
+        "id": 4,
+        "isPrison": false,
+        "isProbation": true,
+        "prisonerSupportNeedId": 3,
+        "status": "MET",
+        "updateText": "Support need met"
+      }
+    ],
+    "caseAllocation": [
+      {
+        "creationDate": "2020-09-01T12:00:00",
+        "deletionDate": "2020-09-02T12:00:00",
+        "id": 1,
+        "isDeleted": true,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      },
+      {
+        "creationDate": "2022-09-01T12:00:00",
+        "deletionDate": "2022-09-02T12:00:00",
+        "id": 2,
+        "isDeleted": true,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      },
+      {
+        "creationDate": "2023-09-01T12:00:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "prisonerId": 1,
+        "staffFirstname": "Michael",
+        "staffId": 999999,
+        "staffLastname": "Scott"
+      }
+    ],
+    "profileTags": [
+      {
+        "id": 1,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "NO_FIXED_ABODE"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      },
+      {
+        "id": 2,
+        "prisonerId": 1,
+        "profileTags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "tags": {
+          "tags": [
+            "HELP_TO_CONTACT_BANK"
+          ]
+        },
+        "updatedDate": "2020-01-01T00:00:00"
+      }
+    ],
+    "todoItems": [
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2020-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "f2b40916-7399-4491-bf96-03b15d114a4d",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2020-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      },
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2022-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "48b6d8c4-be42-492e-bebc-71d4e396676d",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2022-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      },
+      {
+        "completed": false,
+        "createdByUrn": "999999",
+        "creationDate": "2023-09-01T12:00:00",
+        "dueDate": "2030-01-01",
+        "id": "796e405b-2b56-4ba8-a237-15f2151bb1b0",
+        "notes": "This is a to do item",
+        "prisonerId": 1,
+        "title": "Title",
+        "updatedAt": "2023-09-01T12:00:00",
+        "updatedByUrn": "999999"
+      }
+    ],
+    "caseNotes": [
+      {
+        "author": "Matthew Kerry",
+        "id": 1,
+        "nextRuntime": "2020-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2020-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      },
+      {
+        "author": "Matthew Kerry",
+        "id": 2,
+        "nextRuntime": "2022-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2022-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      },
+      {
+        "author": "Matthew Kerry",
+        "id": 3,
+        "nextRuntime": "2023-09-01T12:01:00",
+        "notes": "Case note 1",
+        "originalSubmissionDate": "2023-09-01T12:00:00",
+        "prisonCode": "MDI",
+        "prisoner": {
+          "creationDate": "2024-01-01T12:21:38.709",
+          "id": 1,
+          "nomsId": "G1458GV",
+          "prisonId": null,
+          "supportNeedsLegacyProfile": null
+        },
+        "retryCount": 0,
+        "type": "IMMEDIATE_NEEDS_REPORT"
+      }
+    ],
+    "documents": [
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2020-09-01T12:01:00",
+        "deletionDate": "2020-09-02T12:01:00",
+        "id": 1,
+        "isDeleted": true,
+        "originalDocumentFileName": "license1.pdf",
+        "originalDocumentKey": "8ad7b2e2-7160-4731-8b85-bacf49756a23",
+        "pdfDocumentKey": "c33e3a56-545f-41ee-bb44-632746480f22",
+        "prisonerId": 1
+      },
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2022-09-01T12:01:00",
+        "deletionDate": "2022-09-02T12:01:00",
+        "id": 2,
+        "isDeleted": true,
+        "originalDocumentFileName": "license2.pdf",
+        "originalDocumentKey": "3e5a4c5b-86d8-4617-bfbe-15aa3a91dfd3",
+        "pdfDocumentKey": "32deeb98-30f4-4baa-b187-1b0276736797",
+        "prisonerId": 1
+      },
+      {
+        "category": "LICENCE_CONDITIONS",
+        "creationDate": "2023-09-01T12:01:00",
+        "deletionDate": null,
+        "id": 3,
+        "isDeleted": false,
+        "originalDocumentFileName": "license3.pdf",
+        "originalDocumentKey": "10ad790a-6981-4b9c-bace-604c0468ec5b",
+        "pdfDocumentKey": "ed25e653-607f-428b-9c0d-06cc67465fb7",
+        "prisonerId": 1
       }
     ]
   }

--- a/src/test/resources/testdata/sql/clear-all-data.sql
+++ b/src/test/resources/testdata/sql/clear-all-data.sql
@@ -37,3 +37,4 @@ DELETE from prisoner_support_need;
 ALTER SEQUENCE prisoner_support_need_id_seq RESTART WITH 1;
 DELETE from prisoner;
 ALTER SEQUENCE prisoner_id_seq RESTART WITH 1;
+DELETE from support_need WHERE id = 999999;

--- a/src/test/resources/testdata/sql/seed-sar-data-1.sql
+++ b/src/test/resources/testdata/sql/seed-sar-data-1.sql
@@ -828,3 +828,85 @@ VALUES (46, 1, 'RESETTLEMENT_PLAN', '{
   ]
 }', '2024-05-22 16:06:48.238178', 'Matthew Kerry', 'hello', 'MKERRY_GEN', 'HEALTH', 'SUBMITTED',
         'SUPPORT_DECLINED', '2024-05-22 16:06:54.339643');
+
+INSERT INTO assessment_skip(id, prisoner_id, assessment_type, reason, more_info, created_by, creation_date)
+VALUES(1, 1, '0', 'COMPLETED_IN_OASYS', 'Skipped as completed in OASys', 'MKERRY_GEN', '2020-09-01 12:00:00.000');
+INSERT INTO assessment_skip(id, prisoner_id, assessment_type, reason, more_info, created_by, creation_date)
+VALUES(2, 1, '0', 'EARLY_RELEASE', 'Skipped as on early release', 'MKERRY_GEN', '2022-09-01 12:00:00.000');
+INSERT INTO assessment_skip(id, prisoner_id, assessment_type, reason, more_info, created_by, creation_date)
+VALUES(3, 1, '0', 'OTHER', 'Skipped for other reason', 'MKERRY_GEN', '2023-09-01 12:00:00.000');
+
+INSERT INTO support_need
+(id, pathway, "section", title, hidden, exclude_from_count, allow_other_detail, created_date, is_deleted, deleted_date)
+VALUES(999999, 'ACCOMMODATION', 'Test support need', 'Used for exact creation date', false, false, false, '2020-01-01 00:00:00.000', false, NULL)
+ON CONFLICT DO NOTHING;
+INSERT INTO prisoner_support_need
+(id, prisoner_id, support_need_id, other_detail, created_by, created_date, is_deleted, deleted_date, latest_update_id)
+VALUES(1, 1, 999999, NULL, 'Matthew Kerry', '2020-09-01 12:00:00.000', true, '2023-09-01 12:00:00.000', NULL);
+INSERT INTO prisoner_support_need
+(id, prisoner_id, support_need_id, other_detail, created_by, created_date, is_deleted, deleted_date, latest_update_id)
+VALUES(2, 1, 999999, NULL, 'Matthew Kerry', '2022-09-01 12:00:00.000', false, NULL, NULL);
+INSERT INTO prisoner_support_need
+(id, prisoner_id, support_need_id, other_detail, created_by, created_date, is_deleted, deleted_date, latest_update_id)
+VALUES(3, 1, 999999, NULL, 'Matthew Kerry', '2023-09-01 12:00:00.000', false, NULL, NULL);
+
+INSERT INTO prisoner_support_need_update
+(id, prisoner_support_need_id, created_by, created_date, update_text, status, is_prison, is_probation, is_deleted, deleted_date)
+VALUES(1, 3, 'Matthew Kerry', '2020-09-01 12:00:00.000', 'Support need in progress 1', 'IN_PROGRESS', false, true, true, '2020-09-01 13:00:00.000');
+INSERT INTO prisoner_support_need_update
+(id, prisoner_support_need_id, created_by, created_date, update_text, status, is_prison, is_probation, is_deleted, deleted_date)
+VALUES(2, 3, 'Matthew Kerry', '2020-09-01 14:00:00.000', 'Support need in progress 2', 'IN_PROGRESS', false, true, false, NULL);
+INSERT INTO prisoner_support_need_update
+(id, prisoner_support_need_id, created_by, created_date, update_text, status, is_prison, is_probation, is_deleted, deleted_date)
+VALUES(3, 3, 'Matthew Kerry', '2022-09-01 14:00:00.000', 'Support need in progress 3', 'IN_PROGRESS', false, true, false, NULL);
+INSERT INTO prisoner_support_need_update
+(id, prisoner_support_need_id, created_by, created_date, update_text, status, is_prison, is_probation, is_deleted, deleted_date)
+VALUES(4, 3, 'Matthew Kerry', '2023-09-01 14:00:00.000', 'Support need met', 'MET', false, true, false, NULL);
+
+INSERT INTO case_allocation
+(id, prisoner_id, staff_id, staff_firstname, staff_lastname, is_deleted, when_created, deleted_at)
+VALUES(1, 1, 999999, 'Michael', 'Scott', true, '2020-09-01 12:00:00.000', '2020-09-02 12:00:00.000');
+INSERT INTO case_allocation
+(id, prisoner_id, staff_id, staff_firstname, staff_lastname, is_deleted, when_created, deleted_at)
+VALUES(2, 1, 999999, 'Michael', 'Scott', true, '2022-09-01 12:00:00.000', '2022-09-02 12:00:00.000');
+INSERT INTO case_allocation
+(id, prisoner_id, staff_id, staff_firstname, staff_lastname, is_deleted, when_created, deleted_at)
+VALUES(3, 1, 999999, 'Michael', 'Scott', false, '2023-09-01 12:00:00.000', null);
+
+/* Note: There should only be one profile_tag record per prisoner but it is not enforced the db */
+INSERT INTO profile_tag
+(id, prisoner_id, profile_tags, updated_date)
+VALUES(1, 1, '{"tags": ["NO_FIXED_ABODE"]}'::jsonb, '2020-01-01 00:00:00.000');
+INSERT INTO profile_tag
+(id, prisoner_id, profile_tags, updated_date)
+VALUES(2, 1, '{"tags": ["HELP_TO_CONTACT_BANK"]}'::jsonb, '2020-01-01 00:00:00.000');
+
+INSERT INTO todo_item
+(id, prisoner_id, title, notes, due_date, completed, created_by_urn, updated_by_urn, creation_date, updated_at)
+VALUES('f2b40916-7399-4491-bf96-03b15d114a4d'::uuid, 1, 'Title', 'This is a to do item', '2030-01-01', false, '999999', '999999', '2020-09-01 12:00:00.000', '2020-09-01 12:00:00.000');
+INSERT INTO todo_item
+(id, prisoner_id, title, notes, due_date, completed, created_by_urn, updated_by_urn, creation_date, updated_at)
+VALUES('48b6d8c4-be42-492e-bebc-71d4e396676d'::uuid, 1, 'Title', 'This is a to do item', '2030-01-01', false, '999999', '999999', '2022-09-01 12:00:00.000', '2022-09-01 12:00:00.000');
+INSERT INTO todo_item
+(id, prisoner_id, title, notes, due_date, completed, created_by_urn, updated_by_urn, creation_date, updated_at)
+VALUES('796e405b-2b56-4ba8-a237-15f2151bb1b0'::uuid, 1, 'Title', 'This is a to do item', '2030-01-01', false, '999999', '999999', '2023-09-01 12:00:00.000', '2023-09-01 12:00:00.000');
+
+INSERT INTO case_note_retry
+(id, prisoner_id, "type", notes, author, prison_code, original_submission_date, retry_count, next_runtime)
+VALUES(1, 1, 'IMMEDIATE_NEEDS_REPORT', 'Case note 1', 'Matthew Kerry', 'MDI', '2020-09-01 12:00:00.000', 0, '2020-09-01 12:01:00.000');
+INSERT INTO case_note_retry
+(id, prisoner_id, "type", notes, author, prison_code, original_submission_date, retry_count, next_runtime)
+VALUES(2, 1, 'IMMEDIATE_NEEDS_REPORT', 'Case note 1', 'Matthew Kerry', 'MDI', '2022-09-01 12:00:00.000', 0, '2022-09-01 12:01:00.000');
+INSERT INTO case_note_retry
+(id, prisoner_id, "type", notes, author, prison_code, original_submission_date, retry_count, next_runtime)
+VALUES(3, 1, 'IMMEDIATE_NEEDS_REPORT', 'Case note 1', 'Matthew Kerry', 'MDI', '2023-09-01 12:00:00.000', 0, '2023-09-01 12:01:00.000');
+
+INSERT INTO document_location
+(id, prisoner_id, original_document_key, creation_date, pdf_document_key, category, original_document_file_name, is_deleted, deleted_date)
+VALUES(1, 1, '8ad7b2e2-7160-4731-8b85-bacf49756a23'::uuid, '2020-09-01 12:01:00.000', 'c33e3a56-545f-41ee-bb44-632746480f22'::uuid, 'LICENCE_CONDITIONS', 'license1.pdf', true, '2020-09-02 12:01:00.000');
+INSERT INTO document_location
+(id, prisoner_id, original_document_key, creation_date, pdf_document_key, category, original_document_file_name, is_deleted, deleted_date)
+VALUES(2, 1, '3e5a4c5b-86d8-4617-bfbe-15aa3a91dfd3'::uuid, '2022-09-01 12:01:00.000', '32deeb98-30f4-4baa-b187-1b0276736797'::uuid, 'LICENCE_CONDITIONS', 'license2.pdf', true, '2022-09-02 12:01:00.000');
+INSERT INTO document_location
+(id, prisoner_id, original_document_key, creation_date, pdf_document_key, category, original_document_file_name, is_deleted, deleted_date)
+VALUES(3, 1, '10ad790a-6981-4b9c-bace-604c0468ec5b'::uuid, '2023-09-01 12:01:00.000', 'ed25e653-607f-428b-9c0d-06cc67465fb7'::uuid, 'LICENCE_CONDITIONS', 'license3.pdf', false, null);


### PR DESCRIPTION
Surfaced all information for a prisoner from these tables - within a date range where appropriate:

 * assessment_skip
 * prisoner_support_need
 * prisoner_support_need_update
 * case_allocation
 * profile_tag
 * todo_item
 * case_note_retry
 * document_location