### PR TITLE
RSP-2014: Update API prisoner name/number filter to match DPS search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/CachingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/CachingConfiguration.kt
@@ -21,7 +21,7 @@ class CachingConfiguration(private val buildProperties: BuildProperties) {
 
   @Bean
   fun cacheManager(connectionFactory: RedisConnectionFactory): RedisCacheManager = RedisCacheManager.builder(connectionFactory)
-    .withCacheConfiguration("prisoner-search-api-find-prisoners-by-prison-id", getCacheConfiguration(Duration.ofMinutes(10)))
+    .withCacheConfiguration("prisoner-search-api-find-prisoners-by-search-term", getCacheConfiguration(Duration.ofMinutes(10)))
     .withCacheConfiguration("prisoner-search-api-find-prisoners-personal-details", getCacheConfiguration(Duration.ofMinutes(5)))
     .withCacheConfiguration("interventions-api-fetch-probation-case-referrals", getCacheConfiguration(Duration.ofHours(1)))
     .withCacheConfiguration("allocation-manager-api-get-poms-by-noms-id", getCacheConfiguration(Duration.ofHours(2)))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminService.kt
@@ -40,7 +40,7 @@ class AdminService(
     prisonList.forEach { prisonId ->
       try {
         val numberOfPrisonersAssigned = caseAllocationService.getNumberOfAssignedPrisoners(prisonId)
-        val numberOfPrisonersInPrison = prisonerSearchApiService.findPrisonersByPrisonId(prisonId).size
+        val numberOfPrisonersInPrison = prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "").size
         val percentageOfPrisonersAssigned =
           (numberOfPrisonersAssigned.toDouble() / numberOfPrisonersInPrison.toDouble()) * 100
         telemetryClient.trackMetric(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationService.kt
@@ -162,7 +162,7 @@ class CaseAllocationService(
 
   @Transactional
   fun getCasesAllocationCount(prisonId: String): CasesCountResponse {
-    val prisonerSearchList = prisonerSearchApiService.findPrisonersByPrisonId(prisonId)
+    val prisonerSearchList = prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")
     if (prisonerSearchList.isEmpty()) {
       throw ResourceNotFoundException("PrisonId $prisonId not found")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerService.kt
@@ -87,13 +87,9 @@ class PrisonerService(
         "Page $pageNumber and Size $pageSize",
       )
     }
-    prisonerSearchApiService.findPrisonersByPrisonId(prisonId).forEach {
+    prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, searchTerm).forEach {
       setDisplayedReleaseDate(it)
       prisoners.add(it)
-    }
-
-    if (searchTerm?.isNotBlank() == true) {
-      prisoners.retainAll { searchTermMatchesPrisoner(searchTerm, it) }
     }
 
     processReleaseDateFiltering(days, prisoners, includePastReleaseDates)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ServiceUtils.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ServiceUtils.kt
@@ -8,7 +8,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseNoteTy
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.DeliusCaseNoteType
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.deliusapi.DeliusAuthor
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearch
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ValidationType
@@ -131,11 +130,6 @@ fun convertToDeliusCaseNoteType(assessmentType: ResettlementAssessmentType) = wh
 }
 
 tailrec fun getFibonacciNumber(n: Int, a: Int = 0, b: Int = 1): Long = if (n == 0) a.toLong() else getFibonacciNumber(n - 1, b, a + b)
-
-fun searchTermMatchesPrisoner(searchTerm: String, prisoner: PrisonersSearch): Boolean {
-  val trimmedSearchTerm = searchTerm.trim()
-  return prisoner.prisonerNumber.lowercase() == trimmedSearchTerm.lowercase() || prisoner.firstName.lowercase().startsWith(trimmedSearchTerm.lowercase()) || prisoner.lastName.lowercase().startsWith(trimmedSearchTerm.lowercase())
-}
 
 fun generateLinkOnlyDeliusCaseNoteText(nomsId: String, assessmentType: ResettlementAssessmentType, psfrBaseUrl: String) = """
   ${assessmentType.displayName} report completed.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/PrisonerSearchApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/PrisonerSearchApiService.kt
@@ -15,17 +15,18 @@ class PrisonerSearchApiService(
   private val prisonerSearchWebClientClientCredentials: WebClient,
 ) {
 
-  @Cacheable("prisoner-search-api-find-prisoners-by-prison-id")
-  fun findPrisonersByPrisonId(prisonId: String): List<PrisonersSearch> {
+  @Cacheable("prisoner-search-api-find-prisoners-by-search-term")
+  fun findPrisonersBySearchTerm(prisonId: String, searchTerm: String?): List<PrisonersSearch> {
     val listToReturn = mutableListOf<PrisonersSearch>()
 
     var page = 0
     do {
       val data = prisonerSearchWebClientClientCredentials.get()
         .uri(
-          "/prison/{prisonId}/prisoners?size={size}&page={page}&sort={sort}",
+          "/prison/{prisonId}/prisoners?term={term}&size={size}&page={page}&sort={sort}",
           mapOf(
             "prisonId" to prisonId,
+            "term" to searchTerm,
             // NB: API allows up 3,000 results per page
             "size" to 500,
             "page" to page,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/PrisonerSearchApiService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/PrisonerSearchApiService.kt
@@ -26,7 +26,7 @@ class PrisonerSearchApiService(
           "/prison/{prisonId}/prisoners?term={term}&size={size}&page={page}&sort={sort}",
           mapOf(
             "prisonId" to prisonId,
-            "term" to searchTerm,
+            "term" to (searchTerm ?: ""),
             // NB: API allows up 3,000 results per page
             "size" to 500,
             "page" to page,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AppointmentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AppointmentsIntegrationTest.kt
@@ -131,7 +131,7 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
   fun `Get Appointments when nomsId not found`() {
     val prisonId = "abc"
 
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 404)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 404)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=0&size=10&sort=xxxxx")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationTest.kt
@@ -261,7 +261,7 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
     every { LocalDateTime.now() } returns fakeNow
     val expectedOutput = readFile("testdata/expectation/case-allocation-get-workers-capacity-result.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/workers/capacity?prisonId=$prisonId")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -313,7 +313,7 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
     every { LocalDateTime.now() } returns fakeNow
     val prisonId = "MDI"
     val expectedOutput = " {\"unassignedCount\":10,\"assignedList\":[]} "
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/workers/capacity?prisonId=$prisonId")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -384,7 +384,7 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
     every { LocalDateTime.now() } returns fakeNow
     val expectedOutput1 = readFile("testdata/expectation/case-allocation-post-result-1.json")
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-1.json", "MDI", 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-1.json", "MDI", 500, 0, "", 200)
     val staffId = 485931
 
     webTestClient.post()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersIntegrationTest.kt
@@ -10,7 +10,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners happy path - with caching`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-happy-path.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&page=0&size=10&sort=releaseDate,DESC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -36,7 +36,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners happy path - including past release dates`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-include-past-release-dates.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&page=0&size=10&sort=releaseDate,DESC&includePastReleaseDates=true")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -48,11 +48,11 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-9.sql")
-  fun `Get All Prisoners - PSFR-1495 check caching with and without a search search gets same results`() {
+  fun `Get All Prisoners - check caching, with and without a search term gets different results`() {
     val prisonId = "MDI"
 
     // Stub get prisoners to include Finn Chandlevieve
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
 
     // Call GET prisoners with no search term and assert json
     webTestClient.get()
@@ -63,8 +63,8 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody().json(readFile("testdata/expectation/prisoners.json"), JsonCompareMode.STRICT)
 
-    // Update test stub to remove Finn Chandlevieve
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-4.json", prisonId, 500, 0, 200)
+    // Update test stub to filter on Finn Chandlevieve
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-filtered-1.json", prisonId, 500, 0, "Finn", 200)
 
     // Call GET prisoners with search term and assert json (should use cache and still be there)
     webTestClient.get()
@@ -81,7 +81,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners sort by releaseDate ascending happy path`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-ascending.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&page=0&size=10&sort=releaseDate,ASC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -114,7 +114,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners  Internal Error`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 500)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 500)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -128,7 +128,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners  negative Page number`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 404)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 404)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=-1&size=10&sort=releaseDate,ASC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -143,7 +143,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners  negative Page size`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 404)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 404)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=1&size=-1&sort=releaseDate,ASC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -158,7 +158,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners with no page and no size as Internal Error`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 500)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 500)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?sort=releaseDate,ASC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -172,7 +172,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners with no sort as Internal Error`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 500)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 500)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=1&sie=10")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -186,7 +186,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners with sort invalid`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=0&size=10&sort=xxxxx")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -201,7 +201,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Test
   fun `Get All Prisoners with sort by pathway status- no pathway view selected`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=0&size=10&sort=pathwayStatus,ASC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -217,7 +217,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get Prisoners when nomsId not found`() {
     val prisonId = "abc"
 
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 404)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 404)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?page=0&size=10&sort=xxxxx")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -271,12 +271,12 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:testdata/sql/seed-pathway-statuses-2.sql")
   fun `Get All Prisoners happy path - volume test`() {
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-1.json", prisonId, 500, 0, 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-2.json", prisonId, 500, 1, 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-3.json", prisonId, 500, 2, 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-4.json", prisonId, 500, 3, 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-5.json", prisonId, 500, 4, 200)
-    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-6.json", prisonId, 500, 5, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-1.json", prisonId, 500, 0, "", 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-2.json", prisonId, 500, 1, "", 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-3.json", prisonId, 500, 2, "", 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-4.json", prisonId, 500, 3, "", 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-5.json", prisonId, 500, 4, "", 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-6.json", prisonId, 500, 5, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&page=0&size=10&sort=releaseDate,DESC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -316,7 +316,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners happy path - assessmentRequired true`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-assessment-required.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&assessmentRequired=true&page=0&size=10&sort=releaseDate,DESC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -331,7 +331,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners happy path - assessmentRequired false`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-assessment-not-required.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&assessmentRequired=false&page=0&size=10&sort=releaseDate,DESC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -346,7 +346,7 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
   fun `Get All Prisoners happy path - with assignedworkers`() {
     val expectedOutput = readFile("testdata/expectation/prisoners-with-assigned-workers.json")
     val prisonId = "MDI"
-    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, 200)
+    prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=&page=0&size=10&sort=releaseDate,DESC&includePastReleaseDates=true")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/PrisonersIntegrationTest.kt
@@ -66,7 +66,8 @@ class PrisonersIntegrationTest : IntegrationTestBase() {
     // Update test stub to filter on Finn Chandlevieve
     prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-filtered-1.json", prisonId, 500, 0, "Finn", 200)
 
-    // Call GET prisoners with search term and assert json (should use cache and still be there)
+    // Call GET prisoners with search term and assert json (should not use cache because the search term is different,
+    // so returns the filtered results)
     webTestClient.get()
       .uri("/resettlement-passport/prison/$prisonId/prisoners?term=Finn&page=0&size=10&sort=releaseDate,DESC")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -8,14 +8,14 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.rea
 
 class PrisonerSearchApiMockServer : WireMockServerBase() {
 
-  fun stubGetPrisonersList(prisonId: String, size: Int, page: Int, status: Int) {
-    stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-1.json", prisonId, size, page, status)
+  fun stubGetPrisonersList(prisonId: String, size: Int, page: Int, term: String, status: Int) {
+    stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-1.json", prisonId, size, page, term, status)
   }
 
-  fun stubGetPrisonersList(jsonResponseFile: String, prisonId: String, size: Int, page: Int, status: Int) {
+  fun stubGetPrisonersList(jsonResponseFile: String, prisonId: String, size: Int, page: Int, term: String, status: Int) {
     val prisonersListJSON = readFile(jsonResponseFile)
     stubFor(
-      get("/prison/$prisonId/prisoners?size=$size&page=$page&sort=prisonerNumber").willReturn(
+      get("/prison/$prisonId/prisoners?term=$term&size=$size&page=$page&sort=prisonerNumber").willReturn(
         if (status == 200) {
           jsonSuccess(prisonersListJSON)
         } else {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminServiceTest.kt
@@ -94,10 +94,10 @@ class AdminServiceTest {
     whenever(caseAllocationService.getNumberOfAssignedPrisoners("CCI")).thenReturn(7)
     whenever(caseAllocationService.getNumberOfAssignedPrisoners("DDI")).thenReturn(0)
 
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId("AAI")).thenReturn(getMocks(10))
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId("BBI")).thenReturn(getMocks(35))
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId("CCI")).thenReturn(getMocks(102))
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId("DDI")).thenThrow(RuntimeException("Something went wrong"))
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm("AAI", "")).thenReturn(getMocks(10))
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm("BBI", "")).thenReturn(getMocks(35))
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm("CCI", "")).thenReturn(getMocks(102))
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm("DDI", "")).thenThrow(RuntimeException("Something went wrong"))
 
     whenever(supportNeedRepository.findAll()).thenReturn(
       listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationServiceTest.kt
@@ -257,7 +257,7 @@ class CaseAllocationServiceTest {
     Mockito.`when`(caseAllocationRepository.findCaseCountByPrisonId(prisonId)).thenReturn(caseAllocationCountTestResponseList)
     Mockito.`when`(caseAllocationRepository.findTotalCaseCountByPrisonId(prisonId)).thenReturn(3)
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
     val result = caseAllocationService.getCasesAllocationCount(prisonId)
     Assertions.assertEquals(caseAllocationCountTestResponseList[0].staffId, result.assignedList[0]?.staffId)
     Assertions.assertEquals(7, result.unassignedCount)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
@@ -154,7 +154,7 @@ class PrisonerServiceTest {
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
 
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
       prisonerService.getPrisonersByPrisonId(
@@ -257,7 +257,7 @@ class PrisonerServiceTest {
     val prisonId = "MDI"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
       prisonerService.getPrisonersByPrisonId(
@@ -549,7 +549,7 @@ class PrisonerServiceTest {
     val prisonId = "MDI"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-2.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisoners =
       prisonerService.getPrisonersByPrisonId(
@@ -578,7 +578,7 @@ class PrisonerServiceTest {
     val expectedPrisonerId = "A8339DY"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
       prisonerService.getPrisonersByPrisonId(
@@ -610,7 +610,7 @@ class PrisonerServiceTest {
     val expectedPrisonerId = "G1458GV"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
       prisonerService.getPrisonersByPrisonId(
@@ -638,12 +638,73 @@ class PrisonerServiceTest {
     val expectedPageSize = 3
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-1.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
       prisonerService.getPrisonersByPrisonId("", prisonId, 0, null, null, null, 0, 5, "name,ASC", false, "123", null)
     Assertions.assertEquals(expectedPageSize, prisonersList.pageSize)
     prisonersList.content?.toList()?.let { Assertions.assertEquals(expectedPageSize, it.size) }
+  }
+
+  @Test
+  fun `test get PrisonersList happy path full json with filter on name`() {
+    mockDatabaseCalls()
+
+    val prisonId = "MDI"
+    val searchTerm = "Finn"
+
+    val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-filtered-1.json")
+
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, searchTerm)).thenReturn(mockedJsonResponse.content)
+
+    val prisonersList =
+      prisonerService.getPrisonersByPrisonId(
+        searchTerm,
+        prisonId,
+        0,
+        null,
+        null,
+        null,
+        0,
+        10,
+        "releaseDate,DESC",
+        false,
+        "123",
+        null,
+      )
+
+    val expectedPrisonerList = PrisonersList(
+      content = listOf(
+        Prisoners(
+          prisonerNumber = "G1458GV",
+          firstName = "FINN",
+          middleNames = "CHANDLEVIEVE",
+          lastName = "CRAWFIS",
+          releaseDate = LocalDate.parse("2099-09-12"),
+          releaseType = "CRD",
+          lastUpdatedDate = LocalDate.now(),
+          status = listOf(
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+          ),
+          pathwayStatus = null,
+          homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
+          paroleEligibilityDate = null,
+          releaseEligibilityDate = LocalDate.parse("2018-10-16"),
+          releaseEligibilityType = "HDCED",
+          releaseOnTemporaryLicenceDate = null,
+          assessmentRequired = true,
+          needs = listOf(),
+          lastReport = null,
+        ),
+      ),
+      pageSize = 1,
+      page = 0,
+      sortName = "releaseDate,DESC",
+      totalElements = 1,
+      last = true,
+    )
+    Assertions.assertEquals(expectedPrisonerList, prisonersList)
   }
 
   @Test
@@ -663,7 +724,7 @@ class PrisonerServiceTest {
     )
 
     val mockedJsonResponse: PrisonersSearchList = readStringAsObject(mockedJsonResponseString)
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
     val prisonersList =
       prisonerService.getPrisonersByPrisonId(
         "",
@@ -689,7 +750,7 @@ class PrisonerServiceTest {
     val prisonId = "MDI"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-2.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisoners = prisonerService.getPrisonersByPrisonId(
       "",
@@ -716,7 +777,7 @@ class PrisonerServiceTest {
     val prisonId = "MDI"
 
     val mockedJsonResponse: PrisonersSearchList = readFileAsObject("testdata/prisoner-search-api/prisoner-search-2.json")
-    whenever(prisonerSearchApiService.findPrisonersByPrisonId(prisonId)).thenReturn(mockedJsonResponse.content)
+    whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisoners = prisonerService.getPrisonersByPrisonId(
       "",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ServiceUtilsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ServiceUtilsTest.kt
@@ -341,34 +341,6 @@ class ServiceUtilsTest {
     Arguments.of("Chris", DeliusAuthor("MDI", "Chris", "")),
   )
 
-  @ParameterizedTest
-  @MethodSource("test searchTermMatchesPrisoner data")
-  fun `test searchTermMatchesPrisoner`(searchTerm: String, prisoner: PrisonersSearch, matches: Boolean) {
-    Assertions.assertEquals(matches, searchTermMatchesPrisoner(searchTerm, prisoner))
-  }
-
-  private fun `test searchTermMatchesPrisoner data`() = Stream.of(
-    Arguments.of("", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of(" ", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("ABC1234", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("abc1234", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("Joe", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("joe", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("joE", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("Bloggs", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("bloggs", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("blogGs", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("Jo", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("jo", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("blog", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), true),
-    Arguments.of("ggs", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), false),
-    Arguments.of("oe", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), false),
-    Arguments.of("random string", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), false),
-    Arguments.of("!\"£$%^&*()_-+=[]{};:@'#~<>,.?/`¬|\\ç", getPrisonersSearch("ABC1234", "Joe", "Bloggs"), false),
-    Arguments.of("John", getPrisonersSearch("ABC1234", "John James", "Smith"), true),
-    Arguments.of("  john ", getPrisonersSearch("ABC1234", "John James", "Smith"), true),
-  )
-
   private fun getPrisonersSearch(prisonerNumber: String, firstName: String, lastName: String) = PrisonersSearch(
     prisonerNumber = prisonerNumber,
     firstName = firstName,

--- a/src/test/resources/testdata/prisoner-search-api/prisoner-search-filtered-1.json
+++ b/src/test/resources/testdata/prisoner-search-api/prisoner-search-filtered-1.json
@@ -1,0 +1,164 @@
+{
+  "content": [
+    {
+      "prisonerNumber": "G1458GV",
+      "pncNumber": "91/123362Y",
+      "pncNumberCanonicalShort": "91/123362Y",
+      "pncNumberCanonicalLong": "1991/123362Y",
+      "croNumber": "123362/91G",
+      "bookingId": "897235",
+      "bookNumber": "M88959",
+      "firstName": "FINN",
+      "middleNames": "CHANDLEVIEVE",
+      "lastName": "CRAWFIS",
+      "dateOfBirth": "1974-04-13",
+      "gender": "Male",
+      "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+      "youthOffender": false,
+      "maritalStatus": "Single-not married/in civil partnership",
+      "religion": "Church of England (Anglican)",
+      "nationality": "British",
+      "status": "ACTIVE IN",
+      "lastMovementTypeCode": "ADM",
+      "lastMovementReasonCode": "INT",
+      "inOutStatus": "IN",
+      "prisonId": "MDI",
+      "prisonName": "Moorland (HMP & YOI)",
+      "cellLocation": "6-2-015",
+      "aliases": [
+        {
+          "firstName": "UZNESWE",
+          "lastName": "CATHENTINE",
+          "dateOfBirth": "1974-04-28",
+          "gender": "Male",
+          "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British"
+        }
+      ],
+      "alerts": [
+        {
+          "alertType": "X",
+          "alertCode": "XVL",
+          "active": true,
+          "expired": false
+        },
+        {
+          "alertType": "R",
+          "alertCode": "RDV",
+          "active": true,
+          "expired": false
+        }
+      ],
+      "csra": "Standard",
+      "category": "C",
+      "legalStatus": "SENTENCED",
+      "imprisonmentStatus": "SENT03",
+      "imprisonmentStatusDescription": "Adult Imprisonment Without Option CJA03",
+      "mostSeriousOffence": "Burglary dwelling - with intent to steal",
+      "recall": true,
+      "indeterminateSentence": false,
+      "sentenceStartDate": "2014-10-23",
+      "releaseDate": "2023-12-12",
+      "confirmedReleaseDate": "2099-09-12",
+      "sentenceExpiryDate": "2020-10-06",
+      "licenceExpiryDate": "2020-10-31",
+      "homeDetentionCurfewEligibilityDate": "2018-10-16",
+      "nonDtoReleaseDate": "2018-10-16",
+      "nonDtoReleaseDateType": "CRD",
+      "receptionDate": "2014-08-11",
+      "conditionalReleaseDate": "2018-10-16",
+      "locationDescription": "Moorland (HMP & YOI)",
+      "restrictedPatient": false,
+      "currentIncentive": {
+        "level": {
+          "code": "EN3",
+          "description": "Enhanced 3"
+        },
+        "dateTime": "2022-12-02T09:22:39",
+        "nextReviewDate": "2023-12-02"
+      },
+      "heightCentimetres": 175,
+      "weightKilograms": 76,
+      "hairColour": "Black",
+      "rightEyeColour": "Hazel",
+      "leftEyeColour": "Hazel",
+      "facialHair": "Clean Shaven",
+      "shapeOfFace": "Oval",
+      "build": "Proportional",
+      "tattoos": [
+        {
+          "bodyPart": "Arm",
+          "comment": "FhuSezELhFhuSezELh"
+        },
+        {
+          "bodyPart": "Arm",
+          "comment": "fsmPRpuuoFpiqdifsmPRpuuoFpiqdi"
+        },
+        {
+          "bodyPart": "Neck",
+          "comment": "dIgZdIgZ"
+        },
+        {
+          "bodyPart": "Face",
+          "comment": "txFskkUGIKOjgtxFskkUGIKOjg"
+        },
+        {
+          "bodyPart": "Hand",
+          "comment": "MiqasYwKMiqasYwK"
+        },
+        {
+          "bodyPart": "Neck",
+          "comment": "AHuoAHuo"
+        },
+        {
+          "bodyPart": "Arm",
+          "comment": "ciHouciHo"
+        },
+        {
+          "bodyPart": "Arm",
+          "comment": "NoWAazmBVMIKAhNoWAazmBVMIKA"
+        }
+      ],
+      "scars": [
+        {
+          "bodyPart": "Lip"
+        },
+        {
+          "bodyPart": "Head"
+        },
+        {
+          "bodyPart": "Arm",
+          "comment": "lgWflgW"
+        },
+        {
+          "bodyPart": "Arm",
+          "comment": "gyQkCVRBegyQkCVRBe"
+        }
+      ]
+    }
+  ],
+  "pageable": {
+    "sort": {
+      "empty": true,
+      "sorted": false,
+      "unsorted": true
+    },
+    "offset": 10,
+    "pageSize": 1,
+    "pageNumber": 10,
+    "paged": true,
+    "unpaged": false
+  },
+  "totalElements": 10,
+  "totalPages": 10,
+  "last": true,
+  "size": 1,
+  "number": 10,
+  "sort": {
+    "empty": true,
+    "sorted": false,
+    "unsorted": true
+  },
+  "first": false,
+  "numberOfElements": 1,
+  "empty": false
+}


### PR DESCRIPTION
Enhance the prisoner search functionality on the main PSfR page to utilise the filter by name/number option in the prisoner search API, instead of requesting the full list of prisoners and then performing this filtering locally.