### PR TITLE
[RSP-1952] Ignore any unassigned prisoner(s) during case unallocation processing.

### DIFF
--- a/src/test/resources/testdata/sql/seed-2-prisoner.sql
+++ b/src/test/resources/testdata/sql/seed-2-prisoner.sql
@@ -1,0 +1,4 @@
+INSERT INTO prisoner (id, noms_id, creation_date, prison_id)
+VALUES (1, 'G4161UF', '2024-02-19T09:36:28.713421', 'MDI'),
+       (2, 'G1458GV', '2023-08-16 12:21:38.709', 'MDI');
+


### PR DESCRIPTION
Changes in case unallocation API behaviour so that it does not raise exception upon finding an unassigned prisoner:

- Any prisoner (noms_id) who is unassigned is ignored while processing a case unallocation request.
- API response will only include details for unallocated cases.
- If no cases were unallocated (all noms_ids passed were unassigned), then API response contains an empty list.