### PR TITLE
RSP-2033: SAR report fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/BankApplicationResponse.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/BankApplicationResponse.kt
@@ -9,7 +9,7 @@ data class BankApplicationResponse(
   val logs: List<BankApplicationLog>,
   val applicationSubmittedDate: LocalDateTime,
   val currentStatus: String,
-  val bankName: String,
+  val bankName: String?,
   val bankResponseDate: LocalDateTime? = null,
   val isAddedToPersonalItems: Boolean? = null,
   val addedToPersonalItemsDate: LocalDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/BankApplicationEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/BankApplicationEntity.kt
@@ -35,7 +35,7 @@ data class BankApplicationEntity(
   var status: String,
 
   @Column(name = "bank_name")
-  var bankName: String,
+  var bankName: String?,
 
   @Column(name = "added_to_personal_items")
   var isAddedToPersonalItems: Boolean? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/ProfileTagsEntity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/jpa/entity/ProfileTagsEntity.kt
@@ -34,11 +34,8 @@ data class ProfileTagsEntity(
 
   @Column(name = "updated_date")
   var updatedDate: LocalDateTime? = null,
+)
 
-) {
-  val tags: ProfileTagList
-    get() = profileTags
-}
 data class ProfileTagList(
   var tags: List<String>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SubjectAccessRequestService.kt
@@ -110,7 +110,7 @@ data class ResettlementSarContent(
   val caseAllocations: List<CaseAllocationEntity>,
   val profileTags: List<ProfileTagsEntity>,
   val todoItems: List<TodoEntity>,
-  val documents: Collection<DocumentsEntity>,
+  val documents: List<DocumentsEntity>,
 )
 
 data class ResettlementAssessmentPathwayStatus(

--- a/src/test/resources/testdata/expectation/sar-with-dates-1.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-1.json
@@ -599,22 +599,12 @@
             "NO_FIXED_ABODE"
           ]
         },
-        "tags": {
-          "tags": [
-            "NO_FIXED_ABODE"
-          ]
-        },
         "updatedDate": "2020-01-01T00:00:00"
       },
       {
         "id": 2,
         "prisonerId": 1,
         "profileTags": {
-          "tags": [
-            "HELP_TO_CONTACT_BANK"
-          ]
-        },
-        "tags": {
           "tags": [
             "HELP_TO_CONTACT_BANK"
           ]

--- a/src/test/resources/testdata/expectation/sar-with-dates-2.json
+++ b/src/test/resources/testdata/expectation/sar-with-dates-2.json
@@ -745,22 +745,12 @@
             "NO_FIXED_ABODE"
           ]
         },
-        "tags": {
-          "tags": [
-            "NO_FIXED_ABODE"
-          ]
-        },
         "updatedDate": "2020-01-01T00:00:00"
       },
       {
         "id": 2,
         "prisonerId": 1,
         "profileTags": {
-          "tags": [
-            "HELP_TO_CONTACT_BANK"
-          ]
-        },
-        "tags": {
           "tags": [
             "HELP_TO_CONTACT_BANK"
           ]

--- a/src/test/resources/testdata/expectation/sar-without-dates.json
+++ b/src/test/resources/testdata/expectation/sar-without-dates.json
@@ -810,22 +810,12 @@
             "NO_FIXED_ABODE"
           ]
         },
-        "tags": {
-          "tags": [
-            "NO_FIXED_ABODE"
-          ]
-        },
         "updatedDate": "2020-01-01T00:00:00"
       },
       {
         "id": 2,
         "prisonerId": 1,
         "profileTags": {
-          "tags": [
-            "HELP_TO_CONTACT_BANK"
-          ]
-        },
-        "tags": {
           "tags": [
             "HELP_TO_CONTACT_BANK"
           ]


### PR DESCRIPTION
* Fixed an error caused by null bank names in DB - made field nullable
* Removed the tags field from profile tags as it duplicates existing data
* Made the data type for documents a List for consistency with other fields