### PR TITLE
[RSP-1841] Disable custom prometheus alert on dev and pre-prod

### DIFF
--- a/helm_deploy/hmpps-resettlement-passport-api/templates/prometheus-custom-rules-resettlement-passport.yaml
+++ b/helm_deploy/hmpps-resettlement-passport-api/templates/prometheus-custom-rules-resettlement-passport.yaml
@@ -1,4 +1,7 @@
 {{- $targetNamespace := .Release.Namespace }}
+{{- $targetApplicationBusinessHours := printf "and ON() %s:business_hours" (index .Values "generic-prometheus-alerts" "targetApplication") | replace "-" "_" }}
+{{- $businessOrAllHoursExpression := ternary $targetApplicationBusinessHours "" (index .Values "custom-prometheus-alerts" "businessHoursOnly")}}
+
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -11,7 +14,9 @@ spec:
     - name: resettlement-passport-application-rules
       rules:
         - alert: DatabaseConnectionFailure
-          expr: rate(spring_data_repository_invocations_seconds_count{exception="JDBCConnectionException", namespace="{{ $targetNamespace }}"}[1h]) > 0
+          expr: |-
+            rate(spring_data_repository_invocations_seconds_count{exception="JDBCConnectionException", namespace="{{ $targetNamespace }}"}[1h]) > 0
+            {{ $businessOrAllHoursExpression }}
           for: 5m
           labels:
             severity: {{ index .Values "generic-prometheus-alerts" "alertSeverity" }}

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -33,6 +33,8 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-non-prod
+
+custom-prometheus-alerts:
   businessHoursOnly: true
 
 deploy_stubs: true

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -33,6 +33,7 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-non-prod
+  businessHoursOnly: true
 
 custom-prometheus-alerts:
   businessHoursOnly: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,6 +32,8 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-non-prod
+
+custom-prometheus-alerts:
   businessHoursOnly: true
 
 clamav:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,6 +32,7 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: hmpps-resettlement-passport-non-prod
+  businessHoursOnly: true
 
 custom-prometheus-alerts:
   businessHoursOnly: true


### PR DESCRIPTION
**Summary of changes**
- updated custom rule to capture business rule config.
- updated dev and pre-prod config - `businessHoursOnly` flag moved under `custom-prometheus-alerts` to enable control of custom alerts separate to generic ones.
- updated prometheus expression in custom rule - added additional business hours condition to expression.