### PR TITLE
Security update - update versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,9 +65,6 @@ dependencies {
 
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.1.1")
 
-//  // TODO: Remove once uk.gov.justice.hmpps.gradle-spring-boot version is bump includes the below
-//  implementation("org.springframework.security:spring-security-core:6.4.6")
-
   constraints {
     implementation("io.netty:netty-handler:4.1.118.Final")
   }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
   val kotlinVersion = "2.0.0"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.1.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.2.0"
   id("org.springdoc.openapi-gradle-plugin") version "1.9.0"
   id("jacoco")
   id("org.sonarqube") version "4.0.0.2929"
@@ -47,7 +47,7 @@ dependencies {
   runtimeOnly("org.postgresql:postgresql:42.7.3")
   runtimeOnly("org.flywaydb:flyway-database-postgresql")
 
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.4")
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8")
 
   implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
   implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
@@ -65,8 +65,8 @@ dependencies {
 
   implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:1.1.1")
 
-  // TODO: Remove once uk.gov.justice.hmpps.gradle-spring-boot version is bump includes the below
-  implementation("org.springframework.security:spring-security-core:6.4.6")
+//  // TODO: Remove once uk.gov.justice.hmpps.gradle-spring-boot version is bump includes the below
+//  implementation("org.springframework.security:spring-security-core:6.4.6")
 
   constraints {
     implementation("io.netty:netty-handler:4.1.118.Final")


### PR DESCRIPTION
Update versions to resolve CVE-2025-26791, CVE-2025-46701 and CVE-2025-22233:

- uk.gov.justice.hmpps.gradle-spring-boot -> v8.2.0
- org.springdoc:springdoc-openapi-starter-webmvc-ui -> 2.8.8