### PR TITLE
[RSP-2060] Disable create/update Immediate needs API endpoints

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -28,6 +28,7 @@ generic-service:
     PSFR_BASE_URL: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk
     API_BASE_URL_CURIOUS_SERVICE: http://hmpps-resettlement-passport-api-stubs/curious-api
     API_BASE_URL_MANAGE_USERS_SERVICE: https://manage-users-api-dev.hmpps.service.justice.gov.uk
+    READ_ONLY_MODE_VALUE: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -27,6 +27,7 @@ generic-service:
     PSFR_BASE_URL: https://resettlement-passport-ui-preprod.hmpps.service.justice.gov.uk
     API_BASE_URL_CURIOUS_SERVICE: https://preprodservices.sequation.net
     API_BASE_URL_MANAGE_USERS_SERVICE: https://manage-users-api-preprod.hmpps.service.justice.gov.uk
+    READ_ONLY_MODE_VALUE: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -26,6 +26,7 @@ generic-service:
     PSFR_BASE_URL: https://resettlement-passport-ui.hmpps.service.justice.gov.uk
     API_BASE_URL_CURIOUS_SERVICE: https://liveservices.sequation.com
     API_BASE_URL_MANAGE_USERS_SERVICE: https://manage-users-api.hmpps.service.justice.gov.uk
+    READ_ONLY_MODE_VALUE: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/HmppsResettlementPassportApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/HmppsResettlementPassportApi.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi
 
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.FeatureFlagProperties
 
 /**
  * Used as the system oauth username when calling HMPPS apis
@@ -10,6 +12,7 @@ import org.springframework.boot.runApplication
 const val SYSTEM_USERNAME = "RESETTLEMENT_PASSPORT_API"
 
 @SpringBootApplication()
+@EnableConfigurationProperties(FeatureFlagProperties::class)
 class HmppsResettlementPassportApi
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/aop/FeatureFlagAspect.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/aop/FeatureFlagAspect.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop
+
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.Aspect
+import org.aspectj.lang.annotation.Before
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.expection.OperationNotAllowedException
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.FeatureFlagValueProvider
+
+const val READ_ONLY_MODE_DISABLED = "read-only-mode-disabled"
+
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class RequiresFeature(val featureFlag: String)
+
+@Aspect
+@Component
+class FeatureFlagAspect(private val featureFlagValueProvider: FeatureFlagValueProvider) {
+
+  @Before("@annotation(requiresFeature)")
+  fun checkFeatureFlag(joinPoint: JoinPoint, requiresFeature: RequiresFeature) {
+    val enabled = when (requiresFeature.featureFlag) {
+      READ_ONLY_MODE_DISABLED -> featureFlagValueProvider.isReadOnlyMode()
+      else -> throw IllegalArgumentException("Unknown feature flag: ${requiresFeature.featureFlag}")
+    }
+    if (enabled) {
+      throw OperationNotAllowedException("Feature is disabled due to read-only mode being enabled.")
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/FeatureFlagProperties.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/FeatureFlagProperties.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "app.feature-flags")
+data class FeatureFlagProperties(
+  val readOnlyMode: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/HmppsResettlementPassportApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/HmppsResettlementPassportApiExceptionHandler.kt
@@ -16,11 +16,26 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import org.springframework.web.server.ServerWebInputException
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.expection.OperationNotAllowedException
 import java.time.LocalDate
 import java.util.UUID
 
 @RestControllerAdvice
 class HmppsResettlementPassportApiExceptionHandler {
+
+  @ExceptionHandler(OperationNotAllowedException::class)
+  fun handleOperationNotAllowedException(e: OperationNotAllowedException): ResponseEntity<ErrorResponse> {
+    log.info("Operation not allowed exception: {}", e.message)
+    return ResponseEntity
+      .status(HttpStatus.FORBIDDEN)
+      .body(
+        ErrorResponse(
+          status = HttpStatus.FORBIDDEN.value(),
+          userMessage = "Operation is not allowed - ${e.message}",
+          developerMessage = e.message,
+        ),
+      )
+  }
 
   @ExceptionHandler(AccessDeniedException::class)
   fun handleAccessDeniedException(e: AccessDeniedException): ResponseEntity<ErrorResponse> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/expection/OperationNotAllowedException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/expection/OperationNotAllowedException.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.expection
+
+class OperationNotAllowedException(message: String) : RuntimeException(message)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/ResettlementAssessmentController.kt
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.READ_ONLY_MODE_DISABLED
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.RequiresFeature
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.AssessmentSkipRequest
@@ -48,6 +50,7 @@ class ResettlementAssessmentController(
 ) {
   @PostMapping("/{nomsId}/resettlement-assessment/{pathway}/next-page", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Returns next page of resettlement assessment", description = "Returns next page of resettlement assessment")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(
@@ -192,6 +195,7 @@ class ResettlementAssessmentController(
 
   @PostMapping("/{nomsId}/resettlement-assessment/{pathway}/complete", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Completes a resettlement assessment for the given nomsId and pathway", description = "Completes a resettlement assessment for the given nomsId and pathway")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(
@@ -243,6 +247,7 @@ class ResettlementAssessmentController(
 
   @PostMapping("/{nomsId}/resettlement-assessment/{pathway}/validate", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Validates the given resettlement assessment", description = "Validates the given resettlement assessment")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(
@@ -288,6 +293,7 @@ class ResettlementAssessmentController(
 
   @PostMapping("/{nomsId}/resettlement-assessment/submit", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Submit a completed resettlement assessment for the given nomsId", description = "Submit a completed resettlement assessment for the given nomsId")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(
@@ -392,6 +398,7 @@ class ResettlementAssessmentController(
 
   @PostMapping("/{nomsId}/resettlement-assessment/skip", produces = [MediaType.APPLICATION_JSON_VALUE])
   @Operation(summary = "Skip an assessment")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/SupportNeedsResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/SupportNeedsResourceController.kt
@@ -19,8 +19,6 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.READ_ONLY_MODE_DISABLED
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.RequiresFeature
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PrisonerNeedsRequest
@@ -220,7 +218,6 @@ class SupportNeedsResourceController(
 
   @PostMapping("/{nomsId}/needs")
   @Operation(summary = "POST new support needs and updates for a prisoner", description = "POST new support needs and updates for a prisoner")
-  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/SupportNeedsResourceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/resource/SupportNeedsResourceController.kt
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.READ_ONLY_MODE_DISABLED
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop.RequiresFeature
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PrisonerNeedsRequest
@@ -218,6 +220,7 @@ class SupportNeedsResourceController(
 
   @PostMapping("/{nomsId}/needs")
   @Operation(summary = "POST new support needs and updates for a prisoner", description = "POST new support needs and updates for a prisoner")
+  @RequiresFeature(READ_ONLY_MODE_DISABLED)
   @ApiResponses(
     value = [
       ApiResponse(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/FeatureFlagValueProvider.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/FeatureFlagValueProvider.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.FeatureFlagProperties
+
+@Service
+class FeatureFlagValueProvider(private val featureProperties: FeatureFlagProperties) {
+  fun isReadOnlyMode(): Boolean = featureProperties.readOnlyMode
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -117,3 +117,7 @@ doc.conversion:
 
 psfr:
   base.url: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk
+
+app:
+  feature-flags:
+    readOnlyMode: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -135,3 +135,7 @@ hmpps.s3:
 clamav:
   hostname: localhost
   port: 3310
+
+app:
+  feature-flags:
+    readOnlyMode: ${READ_ONLY_MODE_VALUE}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/aop/FeatureFlagAspectTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/aop/FeatureFlagAspectTest.kt
@@ -1,0 +1,54 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.aop
+
+import org.aspectj.lang.JoinPoint
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.expection.OperationNotAllowedException
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.FeatureFlagValueProvider
+
+class FeatureFlagAspectTest {
+
+  private val joinPoint: JoinPoint = mock()
+  private val featureFlagValueProvider: FeatureFlagValueProvider = mock()
+
+  @Test
+  fun `should allow method when readOnlyMode is false`() {
+    whenever(featureFlagValueProvider.isReadOnlyMode()).thenReturn(false)
+    val aspect = FeatureFlagAspect(featureFlagValueProvider)
+    val annotation = RequiresFeature(READ_ONLY_MODE_DISABLED)
+
+    assertDoesNotThrow {
+      aspect.checkFeatureFlag(joinPoint, annotation)
+    }
+  }
+
+  @Test
+  fun `should block method when readOnlyMode is true`() {
+    whenever(featureFlagValueProvider.isReadOnlyMode()).thenReturn(true)
+    val aspect = FeatureFlagAspect(featureFlagValueProvider)
+    val annotation = RequiresFeature(READ_ONLY_MODE_DISABLED)
+
+    assertThrows<OperationNotAllowedException> {
+      aspect.checkFeatureFlag(joinPoint, annotation)
+    }.apply {
+      assertEquals("Feature is disabled due to read-only mode being enabled.", message)
+    }
+  }
+
+  @Test
+  fun `should throw error on unknown feature flag`() {
+    whenever(featureFlagValueProvider.isReadOnlyMode()).thenReturn(false)
+    val aspect = FeatureFlagAspect(featureFlagValueProvider)
+    val annotation = RequiresFeature("unknown-flag")
+
+    assertThrows<IllegalArgumentException> {
+      aspect.checkFeatureFlag(joinPoint, annotation)
+    }.apply {
+      assertEquals("Unknown feature flag: unknown-flag", message)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationReadOnlyModeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationReadOnlyModeTest.kt
@@ -1,0 +1,156 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.context.annotation.Primary
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.MapAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentRequest
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentRequestQuestionAndAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.FeatureFlagValueProvider
+
+@TestConfiguration
+class TestMockConfig {
+  @Bean
+  @Primary
+  fun featureFlagValueProvider(): FeatureFlagValueProvider = mockk { every { isReadOnlyMode() } returns true }
+}
+
+@Import(TestMockConfig::class)
+class ResettlementAssessmentIntegrationReadOnlyModeTest : IntegrationTestBase() {
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-4.sql")
+  fun `Post resettlement assessment submit - forbidden`() {
+    val nomsId = "ABC1234"
+    val assessmentType = "BCST2"
+
+    webTestClient.post()
+      .uri("resettlement-passport/prisoner/$nomsId/resettlement-assessment/submit?assessmentType=$assessmentType")
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT"), authSource = "nomis"))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-3.sql")
+  fun `Post resettlement assessment complete - forbidden`() {
+    val nomsId = "ABC1234"
+    val pathway = "ACCOMMODATION"
+    val assessmentType = "BCST2"
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/$pathway/complete?assessmentType=$assessmentType&declaration=true")
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        """
+        {
+          "questionsAndAnswers": [
+            {
+              "question": "WHERE_DID_THEY_LIVE",
+              "answer": {
+                "answer": "NO_PERMANENT_OR_FIXED",
+                "@class": "StringAnswer"
+              }
+            }
+          ]
+        }
+        """.trimIndent(),
+      )
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT"), authSource = "nomis"))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-2.sql")
+  fun `Skipping BCST2 assessment when it is not started - forbidden`() {
+    val nomsId = "G4161UF"
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/skip?assessmentType=BCST2")
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .header("Content-Type", "application/json")
+      .bodyValue(
+        """
+          {
+            "reason": "COMPLETED_IN_OASYS",
+            "moreInfo": "something or other"
+          }
+        """,
+      )
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-resettlement-assessment-3.sql")
+  fun `Post resettlement assessment validate - forbidden`() {
+    val nomsId = "ABC1234"
+    val pathway = "ACCOMMODATION"
+    val assessmentType = "BCST2"
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/$pathway/validate?assessmentType=$assessmentType")
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(
+        """
+        {
+          "questionsAndAnswers": [
+            {
+              "question": "WHERE_DID_THEY_LIVE",
+              "answer": {
+                "answer": "NO_PERMANENT_OR_FIXED",
+                "@class": "StringAnswer"
+              }
+            }
+          ]
+        }
+        """.trimIndent(),
+      )
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+
+  @Test
+  @Sql("classpath:testdata/sql/seed-pathway-statuses-2.sql")
+  fun `Post get next assessment page - forbidden`() {
+    val nomsId = "G1458GV"
+    val pathway = "ACCOMMODATION"
+    val assessmentType = "BCST2"
+    val currentPage = "WHERE_DID_THEY_LIVE"
+    val questions = listOf<ResettlementAssessmentRequestQuestionAndAnswer<*>>(
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHERE_DID_THEY_LIVE",
+        answer = StringAnswer("PRIVATE_RENTED_HOUSING"),
+      ),
+      ResettlementAssessmentRequestQuestionAndAnswer(
+        "WHERE_DID_THEY_LIVE_ADDRESS",
+        answer = MapAnswer(
+          listOf(
+            mapOf(
+              "addressLine1" to "123 main street",
+              "city" to "Leeds",
+              "postcode" to "LS1 123",
+            ),
+          ),
+        ),
+      ),
+    )
+    val body = ResettlementAssessmentRequest(
+      questionsAndAnswers = questions,
+    )
+
+    webTestClient.post()
+      .uri("/resettlement-passport/prisoner/$nomsId/resettlement-assessment/$pathway/next-page?assessmentType=$assessmentType&currentPage=$currentPage")
+      .bodyValue(body)
+      .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
+      .exchange()
+      .expectStatus().isForbidden
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/FeatureFlagValueProviderTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/FeatureFlagValueProviderTest.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.FeatureFlagProperties
+
+class FeatureFlagValueProviderTest {
+
+  @Test
+  fun `should return true when readOnlyMode is enabled`() {
+    val mockProperties = mock<FeatureFlagProperties>()
+    whenever(mockProperties.readOnlyMode).thenReturn(true)
+
+    val provider = FeatureFlagValueProvider(mockProperties)
+
+    Assertions.assertTrue(provider.isReadOnlyMode())
+  }
+
+  @Test
+  fun `should return false when readOnlyMode is disabled`() {
+    val mockProperties = mock<FeatureFlagProperties>()
+    whenever(mockProperties.readOnlyMode).thenReturn(false)
+
+    val provider = FeatureFlagValueProvider(mockProperties)
+
+    Assertions.assertFalse(provider.isReadOnlyMode())
+  }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -78,3 +78,7 @@ doc.conversion:
 
 psfr:
   base.url: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk
+
+app:
+  feature-flags:
+    readOnlyMode: false


### PR DESCRIPTION
Overview of work done in PR:

- Leveraging on spike work done - added AOP based implementation with a global feature flag configurable via app config.
- Updated helm files - added new var `READ_ONLY_MODE_VALUE` holding environment specific values.
- Unit test coverage for new classes/functionalities.
- Added Integration test to verify Immediate needs API endpoints when read-only mode is enabled.