### PR TITLE
Upgrade to hmpps.gradle-spring-boot v9.0.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.springframework.boot.gradle.tasks.run.BootRun
 
 plugins {
   val kotlinVersion = "2.0.0"
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "8.3.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "9.0.0"
   id("org.springdoc.openapi-gradle-plugin") version "1.9.0"
   id("jacoco")
   id("org.sonarqube") version "6.2.0.5505"


### PR DESCRIPTION
Resolves CVEs:

- CVE-2025-41242 - HIGH (8.199999809265137) - maven/org.springframework/spring-core@6.2.9
- CVE-2025-21199 -  () - maven/com.microsoft.azure/applicationinsights-agent@3.7.3
- CVE-2025-55163 - HIGH (8.199999809265137) - maven/io.netty/netty-codec-http2@4.1.123.Final
- CVE-2025-48989 -  () - maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.43