### PR TITLE
ESWE-1735: Refactor tests

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/ReadOnlyModeTestConfig.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/config/ReadOnlyModeTestConfig.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config
 
-import io.mockk.every
-import io.mockk.mockk
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.FeatureFlagValueProvider
 
 @TestConfiguration
-class ReadOnlyModeTestMockConfig {
+class ReadOnlyModeTestConfig {
   @Bean
   @Primary
-  fun featureFlagValueProvider(): FeatureFlagValueProvider = mockk { every { isReadOnlyMode() } returns true }
+  fun featureFlagValueProvider() = FeatureFlagValueProvider(FeatureFlagProperties(readOnlyMode = true))
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/events/OffenderEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/events/OffenderEventsServiceTest.kt
@@ -1,15 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.UUIDMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.UUIDMockExtension.Companion.mockRandomUUID
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseAllocationEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
@@ -19,9 +17,9 @@ import java.time.LocalDateTime
 import java.time.ZonedDateTime
 import java.util.*
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, UUIDMockExtension::class)
 class OffenderEventsServiceTest {
-  private lateinit var offenderEventsService: OffenderEventsService
+  private val offenderEventsService by lazy { OffenderEventsService(offenderEventsRepository, pathwayAndStatusService, prisonerRepository, caseAllocationService) }
 
   @Mock
   private lateinit var offenderEventsRepository: OffenderEventRepository
@@ -34,11 +32,6 @@ class OffenderEventsServiceTest {
 
   @Mock
   private lateinit var caseAllocationService: CaseAllocationService
-
-  @BeforeEach
-  fun beforeEach() {
-    offenderEventsService = OffenderEventsService(offenderEventsRepository, pathwayAndStatusService, prisonerRepository, caseAllocationService)
-  }
 
   @Test
   fun `test handleReleaseEvent - no nomsId`() {
@@ -86,9 +79,8 @@ class OffenderEventsServiceTest {
 
   @Test
   fun `test handleReleaseEvent - update prisoner's prisonId to OUT`() {
-    val randomUUID = UUID.randomUUID()
-    mockkStatic(UUID::class)
-    every { UUID.randomUUID() }.returns(randomUUID)
+    val entityId = UUID.randomUUID()
+      .also { mockRandomUUID(it) }
 
     val messageId = "123"
     val event = DomainEvent(
@@ -102,18 +94,13 @@ class OffenderEventsServiceTest {
     offenderEventsService.handleReleaseEvent(messageId, event)
 
     Mockito.verify(prisonerRepository).save(PrisonerEntity(id = 1, nomsId = "abc2", prisonId = "OUT", creationDate = LocalDateTime.parse("2023-10-30T22:09:08")))
-    Mockito.verify(offenderEventsRepository).save(OffenderEventEntity(id = randomUUID, prisonerId = 1, type = OffenderEventType.PRISON_RELEASE, nomsId = "abc2", occurredAt = ZonedDateTime.parse("2024-12-11T12:00:01+00:00"), reasonCode = "12"))
+    Mockito.verify(offenderEventsRepository).save(OffenderEventEntity(id = entityId, prisonerId = 1, type = OffenderEventType.PRISON_RELEASE, nomsId = "abc2", occurredAt = ZonedDateTime.parse("2024-12-11T12:00:01+00:00"), reasonCode = "12"))
     Mockito.verify(caseAllocationService).getCaseAllocationByPrisonerId(1)
     Mockito.verifyNoMoreInteractions(caseAllocationService)
-    unmockkAll()
   }
 
   @Test
   fun `test handleReleaseEvent - Transfer Event`() {
-    val randomUUID = UUID.randomUUID()
-    mockkStatic(UUID::class)
-    every { UUID.randomUUID() }.returns(randomUUID)
-
     val messageId = "123"
     val event = DomainEvent(
       eventType = "prison-offender-events.prisoner.released",
@@ -129,15 +116,10 @@ class OffenderEventsServiceTest {
     Mockito.verifyNoMoreInteractions(offenderEventsRepository)
     Mockito.verify(caseAllocationService).getCaseAllocationByPrisonerId(1)
     Mockito.verifyNoMoreInteractions(caseAllocationService)
-    unmockkAll()
   }
 
   @Test
   fun `test handleReleaseEvent - Transfer Event CaseAllocation available`() {
-    val randomUUID = UUID.randomUUID()
-    mockkStatic(UUID::class)
-    every { UUID.randomUUID() }.returns(randomUUID)
-
     val messageId = "123"
     val event = DomainEvent(
       eventType = "prison-offender-events.prisoner.released",
@@ -156,6 +138,5 @@ class OffenderEventsServiceTest {
     Mockito.verifyNoMoreInteractions(offenderEventsRepository)
     Mockito.verify(caseAllocationService).getCaseAllocationByPrisonerId(1)
     Mockito.verify(caseAllocationService).delete(caseAllocationEntity)
-    unmockkAll()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/helpers/MockExtensions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/helpers/MockExtensions.kt
@@ -1,0 +1,165 @@
+/**
+ * These are mock extensions for static mocks among tests:
+ * - LocalDateTime.now()
+ * - UUID.randomUUID()
+ * - getClaimFromJWTToken(token, claimName)
+ */
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers
+
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.randomAlphaNumericString
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.OffsetDateTime
+import java.util.*
+
+class CurrentDateTimeMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
+  companion object {
+    @JvmField
+    val testDate: LocalDateTime = LocalDateTime.parse("2023-08-16T12:00:00")
+    val fakeNow: LocalDateTime = LocalDateTime.parse("2023-08-17T12:00:01")
+
+    fun mockCurrentTime(now: LocalDateTime = fakeNow) = every { LocalDateTime.now() } returns now
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(LocalDateTime::class)
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    mockCurrentTime()
+    every { LocalDateTime.parse(any<String>()) } answers { callOriginal() }
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(LocalDateTime::class)
+  }
+}
+
+class CurrentOffsetDateTimeMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
+  companion object {
+    @JvmField
+    val fakeNowOffset: OffsetDateTime = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
+
+    fun mockCurrentOffsetTime(now: OffsetDateTime = fakeNowOffset) = every { OffsetDateTime.now() } returns now
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(OffsetDateTime::class)
+    every { OffsetDateTime.parse(any<String>()) } answers { callOriginal() }
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    mockCurrentOffsetTime()
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(OffsetDateTime::class)
+  }
+}
+
+class CurrentDateMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback,
+  BeforeEachCallback {
+  companion object {
+    @JvmField
+    val testDate: LocalDate = LocalDate.parse("2024-08-05")
+
+    fun mockCurrentDate(now: LocalDate = testDate) = every { LocalDate.now() } returns now
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(LocalDate::class)
+  }
+
+  override fun beforeEach(context: ExtensionContext) {
+    mockCurrentDate()
+    every { LocalDate.parse(any<String>()) } answers { callOriginal() }
+    every { any<Int>().let { LocalDate.of(it, it, it) } } answers { callOriginal() }
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(LocalDate::class)
+  }
+}
+
+class UUIDMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback {
+  companion object {
+    fun mockRandomUUID(uuid: UUID) = every { UUID.randomUUID() }.returns(uuid)
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(UUID::class)
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(UUID::class)
+  }
+}
+
+class JWTTokenMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback {
+  companion object {
+    fun mockClaimFromJWTToken(
+      token: String = "auth",
+      claimValue: String? = "USERNAME",
+      claimName: String = "sub",
+    ) = every { getClaimFromJWTToken(token, claimName) } returns claimValue
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(::getClaimFromJWTToken)
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(::getClaimFromJWTToken)
+  }
+}
+
+class ServiceUtilsMockExtension :
+  MockkMockExtension(),
+  BeforeAllCallback,
+  AfterAllCallback,
+  AfterEachCallback {
+  companion object {
+    fun mockRandomAlphaNumericString(value: String) = every { randomAlphaNumericString() } returns value
+  }
+
+  override fun beforeAll(context: ExtensionContext) {
+    mockkStatic(::randomAlphaNumericString)
+  }
+
+  override fun afterAll(context: ExtensionContext) {
+    unmockkStatic(::randomAlphaNumericString)
+  }
+}
+
+abstract class MockkMockExtension : AfterEachCallback {
+  override fun afterEach(context: ExtensionContext) {
+    clearAllMocks()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ATBResettlementAssessmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ATBResettlementAssessmentIntegrationTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
-import io.mockk.unmockkAll
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -319,7 +318,6 @@ class ATBResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test
@@ -338,7 +336,6 @@ class ATBResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AppointmentsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AppointmentsIntegrationTest.kt
@@ -5,21 +5,23 @@ import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath
 import com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor
 import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CreateAppointment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CreateAppointmentAddress
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateMockExtension.Companion.mockCurrentDate
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Category
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateMockExtension::class)
 class AppointmentsIntegrationTest : IntegrationTestBase() {
-  private val fakeNow = LocalDate.parse("2024-08-19")
+  private val testDate = LocalDate.parse("2024-08-19")
 
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-2.sql")
@@ -30,6 +32,8 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
     deliusApiMockServer.stubGetCrnFromNomsId(nomsId, crn)
     deliusApiMockServer.stubGetAllAppointmentsFromCRN(crn, 200)
     interventionsServiceApiMockServer.stubGetCRSAppointmentsFromCRN(crn, 200)
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+
     webTestClient.get()
       .uri("/resettlement-passport/prisoner/$nomsId/appointments?futureOnly=false&page=0&size=50")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -145,14 +149,15 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-6.sql")
   fun `Get All Appointments happy path - including database`() {
-    mockkStatic(LocalDate::class)
-    every { LocalDate.now() } returns fakeNow
+    mockCurrentDate(testDate)
     val expectedOutput = readFile("testdata/expectation/appointments-2.json")
     val nomsId = "G1458GV"
     val crn = "CRN1"
     deliusApiMockServer.stubGetCrnFromNomsId(nomsId, crn)
     deliusApiMockServer.stubGetAppointmentsFromCRN(crn, 200)
     interventionsServiceApiMockServer.stubGetCRSAppointmentsFromCRN(crn, 200)
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+
     webTestClient.get()
       .uri("/resettlement-passport/prisoner/$nomsId/appointments?page=0&size=50")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -282,14 +287,15 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-pathway-statuses-2.sql")
   fun `Get All Future Appointments only happy path`() {
-    mockkStatic(LocalDate::class)
-    every { LocalDate.now() } returns fakeNow
+    mockCurrentDate(testDate)
     val expectedOutput = readFile("testdata/expectation/appointments-1.json")
     val nomsId = "G1458GV"
     val crn = "CRN1"
     deliusApiMockServer.stubGetCrnFromNomsId(nomsId, crn)
     deliusApiMockServer.stubGetAppointmentsFromCRN(crn, 200)
     interventionsServiceApiMockServer.stubGetCRSAppointmentsFromCRN(crn, 200)
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+
     webTestClient.get()
       .uri("/resettlement-passport/prisoner/$nomsId/appointments")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -312,6 +318,8 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
     deliusApiMockServer.stubGetCrnFromNomsId(nomsId, crn)
     deliusApiMockServer.stubGetAppointmentsFromCRNNoResults(crn)
     interventionsServiceApiMockServer.stubGetCRSAppointmentsFromCRNNoResults(crn, 200)
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+
     webTestClient.get()
       .uri("/resettlement-passport/prisoner/$nomsId/appointments")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))
@@ -335,6 +343,8 @@ class AppointmentsIntegrationTest : IntegrationTestBase() {
     deliusApiMockServer.stubGetCrnFromNomsId(nomsId, crn)
     deliusApiMockServer.stubGetAppointmentsFromCRNNoResults(crn)
     interventionsServiceApiMockServer.stubGetCRSAppointmentsFromCRNNoReferrals(crn, 200)
+    prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
+
     webTestClient.get()
       .uri("/resettlement-passport/prisoner/$nomsId/appointments")
       .headers(setAuthorisation(roles = listOf("ROLE_RESETTLEMENT_PASSPORT_EDIT")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AssessmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/AssessmentIntegrationTest.kt
@@ -1,24 +1,30 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.jdbc.Sql
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Assessment
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class AssessmentIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
+  @BeforeEach
+  internal fun setUp() {
+    mockCurrentTime(fakeNow)
+  }
+
   @Test
   @Sql("classpath:testdata/sql/seed-assessment-1.sql")
   fun `Get assessment by noms ID - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val expectedOutput = readFile("testdata/expectation/assessment-1.json")
 
     val nomsId = "123"
@@ -36,9 +42,6 @@ class AssessmentIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-assessment-1.sql")
   fun `Get assessment by noms ID - Not found`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val nomsId = "1234"
 
     webTestClient.get()
@@ -51,9 +54,6 @@ class AssessmentIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-assessment-2.sql")
   fun `create assessment - Happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val nomsId = "123"
 
     webTestClient.get()
@@ -93,9 +93,6 @@ class AssessmentIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-assessment-1.sql")
   fun `delete assessment by ID - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val nomsId = "123"
 
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/BankApplicationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/BankApplicationIntegrationTest.kt
@@ -1,15 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.jdbc.Sql
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.BankApplication
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class BankApplicationIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
@@ -17,8 +19,7 @@ class BankApplicationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-bank-application.sql")
   fun `Create, update and delete bank application- happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     val expectedOutput = readFile("testdata/expectation/bank-application.json")
     val expectedOutput2 = readFile("testdata/expectation/bank-application2.json")
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationReadOnlyModeTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationReadOnlyModeTest.kt
@@ -1,21 +1,27 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
-import io.mockk.every
-import io.mockk.mockkStatic
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseAllocation
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class CaseAllocationIntegrationReadOnlyModeTest : ReadOnlyIntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
+  @BeforeEach
+  internal fun setUp() {
+    mockCurrentTime(fakeNow)
+  }
+
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Assign, UnAssign Case Allocation - forbidden`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
 
     val staffId = 485931
@@ -45,8 +51,6 @@ class CaseAllocationIntegrationReadOnlyModeTest : ReadOnlyIntegrationTestBase() 
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner-case-allocation.sql")
   fun `UnAssign Case Allocation - forbidden`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
     val staffId = 456769
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/CaseAllocationIntegrationTest.kt
@@ -1,24 +1,30 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.jdbc.Sql
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseAllocation
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class CaseAllocationIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
+  @BeforeEach
+  internal fun setUp() {
+    mockCurrentTime(fakeNow)
+  }
+
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Assign, UnAssign Case Allocation - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
 
     val expectedOutput1 = readFile("testdata/expectation/case-allocation-post-result.json")
@@ -86,8 +92,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-2-prisoner.sql")
   fun `Assign, UnAssign Case Allocation - where one prisoner is unallocated`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
 
     val expectedOutput1 = readFile("testdata/expectation/case-allocation-post-result.json")
@@ -155,8 +159,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Assign Case Allocation for already exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersDataEmptyList(200)
     val expectedOutput1 = readFile("testdata/expectation/case-allocation-post-result.json")
     val expectedOutput2 = readFile("testdata/expectation/case-allocation-get-result.json")
@@ -214,9 +216,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Unassign Case Allocation for not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     webTestClient.patch()
       .uri("/resettlement-passport/workers/cases")
       .bodyValue(
@@ -269,9 +268,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Get workers list for prison Id`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val expectedOutput = readFile("testdata/expectation/case-allocation-get-workers-result.json")
     val prisonId = "MDI"
     manageUsersApiMockServer.stubGetManageUsersData(prisonId, 200)
@@ -288,9 +284,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Get workers list for prison Id not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val prisonId = "MDI1"
     manageUsersApiMockServer.stubGetManageUsersDataEmptyList(200)
     webTestClient.get()
@@ -326,8 +319,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-case-allocation.sql")
   fun `Get workers capacity for prison Id with sort`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val expectedOutput = readFile("testdata/expectation/case-allocation-get-workers-capacity-result.json")
     val prisonId = "MDI"
     prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
@@ -343,9 +334,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-case-allocation.sql")
   fun `Get workers capacity for prison Id not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val prisonId = "MDI1"
     webTestClient.get()
       .uri("/resettlement-passport/workers/capacity?prisonId=$prisonId")
@@ -378,8 +366,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-prisoners-2.sql")
   fun `Get workers capacity for prison Id with zero assigned`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonId = "MDI"
     val expectedOutput = " {\"unassignedCount\":10,\"assignedList\":[]} "
     prisonerSearchApiMockServer.stubGetPrisonersList(prisonId, 500, 0, "", 200)
@@ -395,8 +381,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Assign Case Allocation StaffId not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
 
     val staffId = 4859311
@@ -422,9 +406,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-1-prisoner.sql")
   fun `Assign Case Allocation PrisonId not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
 
     val staffId = 4859311
@@ -449,8 +430,6 @@ class CaseAllocationIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `Assign Case Allocation Prisoner not exists`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val expectedOutput1 = readFile("testdata/expectation/case-allocation-post-result-1.json")
     manageUsersApiMockServer.stubGetManageUsersData("MDI", 200)
     prisonerSearchApiMockServer.stubGetPrisonersList("testdata/prisoner-search-api/prisoner-search-volume-test-1.json", "MDI", 500, 0, "", 200)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/DocumentStorageIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/DocumentStorageIntegrationTest.kt
@@ -2,20 +2,22 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.google.common.io.Resources
-import io.mockk.every
-import io.mockk.mockkStatic
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.core.io.ByteArrayResource
 import org.springframework.http.client.MultipartBodyBuilder
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.web.reactive.function.BodyInserters
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.DocumentResponse
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class DocumentStorageIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2024-07-26T12:00:01")
@@ -329,8 +331,7 @@ class DocumentStorageIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:testdata/sql/seed-document-upload.sql")
   fun `Create uploadDocument pdf and getDocument pdf without conversion - happy path`() {
     val nomsId = "ABC1234"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     webTestClient.post()
       .uri("/resettlement-passport/prisoner/$nomsId/documents/upload")
       .body(generateMultiPartFormRequestWeb("testdata/example-doc.pdf"))
@@ -354,8 +355,7 @@ class DocumentStorageIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:testdata/sql/seed-document-upload.sql")
   fun `Uses original filename field when it is supplied`() {
     val nomsId = "ABC1234"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     webTestClient.post()
       .uri("/resettlement-passport/prisoner/$nomsId/documents/upload")
       .body(generateMultiPartFormRequestWeb("testdata/example-doc.pdf", originalFilename = "original-filename.pdf"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/IdApplicationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/IdApplicationIntegrationTest.kt
@@ -1,17 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
 import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.test.context.jdbc.Sql
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.IdApplicationPatch
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.IdApplicationPost
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class IdApplicationIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
@@ -19,8 +21,7 @@ class IdApplicationIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-bank-application.sql")
   fun `Create, update and delete bank application- happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     val expectedOutput = readFile("testdata/expectation/id-application-post-result.json")
     val expectedOutput2 = readFile("testdata/expectation/id-application-patch-result.json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/IntegrationTestBase.kt
@@ -20,7 +20,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import software.amazon.awssdk.services.sqs.model.GetQueueUrlRequest
 import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ReadOnlyModeTestMockConfig
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ReadOnlyModeTestConfig
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JwtAuthHelper
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wiremock.AllocationManagerApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wiremock.ArnApiMockServer
@@ -179,7 +179,8 @@ abstract class IntegrationTestBase : TestBase() {
       registry.add("api.base.url.manage-users-service") { "http://localhost:${manageUsersApiMockServer.port()}" }
     }
 
-    fun readFile(file: String): String = this::class.java.getResource("/$file")!!.readText()
+    @JvmStatic
+    protected fun readFile(file: String): String = this::class.java.getResource("/$file")!!.readText()
   }
 
   init {
@@ -195,7 +196,5 @@ abstract class IntegrationTestBase : TestBase() {
   ): (HttpHeaders) -> Unit = jwtAuthHelper.setAuthorisation(user, roles, scopes, authSource)
 }
 
-@Import(ReadOnlyModeTestMockConfig::class)
+@Import(ReadOnlyModeTestConfig::class)
 abstract class ReadOnlyIntegrationTestBase : IntegrationTestBase()
-
-fun readFile(file: String): String = IntegrationTestBase.readFile(file)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ProfileResetIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ProfileResetIntegrationTest.kt
@@ -1,12 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Sort
 import org.springframework.test.context.jdbc.Sql
@@ -17,6 +15,8 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.ResetReaso
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Status
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNeedStatus
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentStatus
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PathwayStatusEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedEntity
@@ -32,6 +32,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.SupportNeedRepository
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class ProfileResetIntegrationTest : IntegrationTestBase() {
 
   @Autowired
@@ -57,8 +58,7 @@ class ProfileResetIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-profile-reset.sql")
   fun `POST reset profile - happy path and supportNeeds enabled`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     val nomsId = "ABC1234"
     val prisonId = "MDI"
@@ -125,15 +125,12 @@ class ProfileResetIntegrationTest : IntegrationTestBase() {
     // Prisoner should have supportNeedsLegacyProfile set to false
     val expectedPrisoner = PrisonerEntity(1, "ABC1234", LocalDateTime.parse("2023-08-16T12:21:38.709"), "MDI", false)
     Assertions.assertEquals(expectedPrisoner, prisonerRepository.findById(1).get())
-
-    unmockkAll()
   }
 
   @Test
   @Sql("classpath:testdata/sql/seed-profile-reset.sql")
   fun `POST reset profile - happy path and supportNeeds disabled, send legacy case notes`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     val nomsId = "ABC1234"
     val prisonId = "MDI"
@@ -215,8 +212,6 @@ class ProfileResetIntegrationTest : IntegrationTestBase() {
       PrisonerSupportNeedUpdateEntity(id = 102, prisonerSupportNeedId = 2, createdBy = "A user", createdDate = LocalDateTime.parse("2024-02-22T09:36:30.713421"), updateText = "This is an update 2", status = SupportNeedStatus.IN_PROGRESS, isPrison = true, isProbation = false, deleted = false, deletedDate = null),
     )
     Assertions.assertEquals(expectedPrisonerSupportNeedUpdates, prisonerSupportNeedUpdateRepository.findAll().sortedBy { it.id })
-
-    unmockkAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/ResettlementAssessmentIntegrationTest.kt
@@ -1,11 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
@@ -18,6 +16,10 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettleme
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentRequestQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentStatus
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentOffsetDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentOffsetDateTimeMockExtension.Companion.mockCurrentOffsetTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PathwayStatusEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentEntity
@@ -31,9 +33,11 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class, CurrentOffsetDateTimeMockExtension::class)
 class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
 
   private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
+  private val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
   @Autowired
   private lateinit var resettlementAssessmentRepository: ResettlementAssessmentRepository
@@ -163,8 +167,7 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:testdata/sql/seed-resettlement-assessment-1.sql")
   fun `Get resettlement assessment summary by noms ID - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     val expectedOutput = readFile("testdata/expectation/resettlement-assessment-summary-1.json")
 
     val nomsId = "G4161UF"
@@ -178,14 +181,12 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput)
-    unmockkAll()
   }
 
   @Test
   @Sql("classpath:testdata/sql/seed-resettlement-assessment-1-deleted.sql")
   fun `Get resettlement assessment summary by noms ID - happy path with deleted entries`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     val expectedOutput = readFile("testdata/expectation/resettlement-assessment-summary-1.json")
 
     val nomsId = "G4161UF"
@@ -199,14 +200,12 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput)
-    unmockkAll()
   }
 
   @Test
   @Sql("classpath:testdata/sql/seed-resettlement-assessment-2.sql")
   fun `Get resettlement assessment summary by noms ID- no assessments in DB - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     val expectedOutput = readFile("testdata/expectation/resettlement-assessment-summary-2.json")
 
     val nomsId = "G4161UF"
@@ -220,7 +219,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput)
-    unmockkAll()
   }
 
   @Test
@@ -532,10 +530,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val forename = "A"
     val surname = "User"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", caseNoteText, prisonId, 200)
@@ -580,8 +576,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val prisoner = prisonerRepository.findById(1).get()
     val expectedPrisoner = PrisonerEntity(1, "ABC1234", LocalDateTime.parse("2023-08-16T12:21:38.709"), "MDI", null)
     Assertions.assertEquals(expectedPrisoner, prisoner)
-
-    unmockkAll()
   }
 
   @Test
@@ -594,10 +588,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val forename = "A"
     val surname = "User"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "PRR", caseNoteText, prisonId, 200)
@@ -642,8 +634,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val prisoner = prisonerRepository.findById(1).get()
     val expectedPrisoner = PrisonerEntity(1, "ABC1234", LocalDateTime.parse("2023-08-16T12:21:38.709"), "MDI", true)
     Assertions.assertEquals(expectedPrisoner, prisoner)
-
-    unmockkAll()
   }
 
   @Test
@@ -656,10 +646,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val forename = "A"
     val surname = "User"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "PRR", caseNoteText, prisonId, 200)
@@ -704,8 +692,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val prisoner = prisonerRepository.findById(1).get()
     val expectedPrisoner = PrisonerEntity(1, "ABC1234", LocalDateTime.parse("2023-08-16T12:21:38.709"), "MDI", null)
     Assertions.assertEquals(expectedPrisoner, prisoner)
-
-    unmockkAll()
   }
 
   @Test
@@ -718,10 +704,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val forename = "A"
     val surname = "User"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", caseNoteText, prisonId, 200)
@@ -761,8 +745,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-
-    unmockkAll()
   }
 
   @Test
@@ -776,10 +758,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val surname = "Smith"
     val dpsCaseNoteText = "Immediate needs report completed.\\n\\nGo to prepare someone for release (PSfR) service to see the report information."
     val deliusCaseNoteText = "Immediate needs report completed.\\n\\nView accommodation report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/accommodation/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView attitudes, thinking and behaviour report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/attitudes-thinking-and-behaviour/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView children, families and communities report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/children-families-and-communities/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView drugs and alcohol report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/drugs-and-alcohol/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView education, skills and work report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/education-skills-and-work/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView finance and ID report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/finance-and-id/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView health report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/health-status/?prisonerNumber=ABC1234&fromDelius=true#assessment-information"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", dpsCaseNoteText, prisonId, 200)
@@ -819,8 +799,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-
-    unmockkAll()
   }
 
   @Test
@@ -834,10 +812,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val surname = "Smith"
     val dpsCaseNoteText = "Immediate needs report completed.\\n\\nGo to prepare someone for release (PSfR) service to see the report information."
     val deliusCaseNoteText = "Immediate needs report completed.\\n\\nView accommodation report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/accommodation/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView attitudes, thinking and behaviour report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/attitudes-thinking-and-behaviour/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView children, families and communities report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/children-families-and-communities/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView drugs and alcohol report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/drugs-and-alcohol/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView education, skills and work report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/education-skills-and-work/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView finance and ID report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/finance-and-id/?prisonerNumber=ABC1234&fromDelius=true#assessment-information\\nView health report information in PSfR: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk/health-status/?prisonerNumber=ABC1234&fromDelius=true#assessment-information"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", dpsCaseNoteText, prisonId, 200)
@@ -877,8 +853,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-
-    unmockkAll()
   }
 
   @Test
@@ -895,10 +869,7 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val caseNoteText1 = "Part 1 of 2\\n\\nAccommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour"
     val caseNoteText2 = "Part 2 of 2\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
 
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
-
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", caseNoteText1, prisonId, 200)
@@ -940,7 +911,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-    unmockkAll()
   }
 
   @Test
@@ -951,10 +921,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val assessmentType = "BCST2"
     val prisonId = "MDI"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", caseNoteText, prisonId, 200)
@@ -994,8 +962,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-
-    unmockkAll()
   }
 
   @Test
@@ -1005,10 +971,8 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     val assessmentType = "BCST2"
     val prisonId = "MDI"
     val caseNoteText = "Accommodation\\n\\nCase note related to accommodation\\n\\n\\nAttitudes, thinking and behaviour\\n\\nCase note related to Attitudes, thinking and behaviour\\n\\n\\nChildren, families and communities\\n\\nCase note related to Children, family and communities\\n\\n\\nDrugs and alcohol\\n\\nCase note related to Drugs and alcohol\\n\\n\\nEducation, skills and work\\n\\nCase note related to education, skills and work\\n\\n\\nFinance and ID\\n\\nCase note related to Finance and ID\\n\\n\\nHealth\\n\\nCase note related to Health"
-    val fakeNowOffset = OffsetDateTime.parse("2024-06-04T09:16:04+01:00")
 
-    mockkStatic(OffsetDateTime::class)
-    every { OffsetDateTime.now() } returns fakeNowOffset
+    mockCurrentOffsetTime(fakeNowOffset)
 
     prisonerSearchApiMockServer.stubGetPrisonerDetails(nomsId, 200)
     caseNotesApiMockServer.stubPostCaseNotes(nomsId, "RESET", "INR", caseNoteText, prisonId, 200)
@@ -1047,8 +1011,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
     )
 
     assertThat(pathwayStatusesInDatabase).usingRecursiveComparison().ignoringFieldsOfTypes(LocalDateTime::class.java).isEqualTo(expectedPathwayStatuses)
-
-    unmockkAll()
   }
 
   @Test
@@ -1130,7 +1092,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test
@@ -1149,7 +1110,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test
@@ -1168,7 +1128,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test
@@ -1187,7 +1146,6 @@ class ResettlementAssessmentIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType("application/json")
       .expectBody()
       .json(expectedOutput, JsonCompareMode.STRICT)
-    unmockkAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/SchedulerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/SchedulerIntegrationTest.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PoPUserOTPEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PoPUserOTPRepository
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.Schedul
 import java.time.LocalDate
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class SchedulerIntegrationTest : IntegrationTestBase() {
 
   @Autowired
@@ -36,12 +37,10 @@ class SchedulerIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:testdata/sql/seed-pop-user-otp-3.sql")
   fun `test expired otp in database - happy path`() {
     val fakeNow = LocalDateTime.parse("2024-02-19T10:18:22.636066")
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
     val expectedOTPEntities = getExpectedPoPUserOTPEntities()
     schedulerService.deleteExpiredOTPScheduledTask()
     Assertions.assertEquals(expectedOTPEntities, popUserOTPRepository.findAll().sortedBy { it.id })
-    unmockkStatic(LocalDateTime::class)
   }
 
   private fun getExpectedPoPUserOTPEntities(): List<PoPUserOTPEntity> {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/SupportNeedsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/SupportNeedsIntegrationTest.kt
@@ -1,15 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
-import org.junit.jupiter.api.AfterAll
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.json.JsonCompareMode
@@ -19,6 +16,8 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PrisonerNe
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PrisonerNeedsRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNeedStatus
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNeedsUpdateRequest
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedUpdateEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerSupportNeedRepository
@@ -26,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.SupportNeedRepository
 import java.time.LocalDateTime
 
+@ExtendWith(CurrentDateTimeMockExtension::class)
 class SupportNeedsIntegrationTest : IntegrationTestBase() {
 
   @Autowired
@@ -39,19 +39,11 @@ class SupportNeedsIntegrationTest : IntegrationTestBase() {
 
   companion object {
     val fakeNow: LocalDateTime = LocalDateTime.parse("2025-01-09T12:00:00")
+  }
 
-    @JvmStatic
-    @BeforeAll
-    fun beforeAll() {
-      mockkStatic(LocalDateTime::class)
-      every { LocalDateTime.now() } returns fakeNow
-    }
-
-    @JvmStatic
-    @AfterAll
-    fun afterAll() {
-      unmockkAll()
-    }
+  @BeforeEach
+  internal fun setUp() {
+    mockCurrentTime(fakeNow)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
@@ -106,24 +106,11 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
       assertThat(savedOffenderEvent).hasSize(1)
-      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
-        .isEqualTo(
-          OffenderEventEntity(
-            id = UUID.randomUUID(),
-            prisonerId = 1,
-            nomsId = "A4092EA",
-            type = OffenderEventType.PRISON_RELEASE,
-            occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"),
-            reason = null,
-            reasonCode = "NCS",
-            creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329"),
-          ),
-        )
+      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate").isEqualTo(OffenderEventEntity(id = UUID.randomUUID(), prisonerId = 1, nomsId = "A4092EA", type = OffenderEventType.PRISON_RELEASE, occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"), reason = null, reasonCode = "NCS", creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329")))
 
       val savedPrisoner = prisonerRepository.findAll()
       assertThat(savedPrisoner).hasSize(1)
-      assertThat(savedPrisoner[0])
-        .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
+      assertThat(savedPrisoner[0]).isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
     }
   }
 
@@ -138,24 +125,11 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
       assertThat(savedOffenderEvent).hasSize(1)
-      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
-        .isEqualTo(
-          OffenderEventEntity(
-            id = UUID.randomUUID(),
-            prisonerId = 1,
-            nomsId = "A4092EA",
-            type = OffenderEventType.PRISON_RELEASE,
-            occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"),
-            reason = null,
-            reasonCode = "NCS",
-            creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329"),
-          ),
-        )
+      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate").isEqualTo(OffenderEventEntity(id = UUID.randomUUID(), prisonerId = 1, nomsId = "A4092EA", type = OffenderEventType.PRISON_RELEASE, occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"), reason = null, reasonCode = "NCS", creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329")))
 
       val savedPrisoner = prisonerRepository.findAll()
       assertThat(savedPrisoner).hasSize(1)
-      assertThat(savedPrisoner[0])
-        .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
+      assertThat(savedPrisoner[0]).isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
 
       val savedCaseAllocation = caseAllocationRepository.findByPrisonerIdAndIsDeleted(1, true)
       assertThat(savedCaseAllocation).isNotNull

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
@@ -1,15 +1,18 @@
-package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events
+package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.events
 
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
+import org.assertj.core.api.Assertions
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events.MovementReasonType
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events.OffenderEventEntity
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events.OffenderEventRepository
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.events.OffenderEventType
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.IntegrationTestBase
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.CaseAllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
@@ -17,7 +20,7 @@ import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.MissingQueueException
 import java.time.LocalDateTime
 import java.time.ZonedDateTime
-import java.util.*
+import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -54,11 +57,11 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val saved = offenderEventRepository.findAllByPrisonerId(1)
-      assertThat(saved).hasSize(1)
-      assertThat(saved[0].reason).isEqualTo(MovementReasonType.RECALL)
+      Assertions.assertThat(saved).hasSize(1)
+      Assertions.assertThat(saved[0].reason).isEqualTo(MovementReasonType.RECALL)
     }
     val prisoner = prisonerRepository.getReferenceById(1)
-    assertThat(prisoner.prisonId).describedAs { "Prison id should be updated" }.isEqualTo("SWI")
+    Assertions.assertThat(prisoner.prisonId).describedAs { "Prison id should be updated" }.isEqualTo("SWI")
   }
 
   @Sql("classpath:testdata/sql/seed-prisoners-for-events.sql")
@@ -71,8 +74,8 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val saved = offenderEventRepository.findAllByPrisonerId(1)
-      assertThat(saved).hasSize(1)
-      assertThat(saved[0].reason).isNull()
+      Assertions.assertThat(saved).hasSize(1)
+      Assertions.assertThat(saved[0].reason).isNull()
     }
   }
 
@@ -85,10 +88,10 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val createdPrisoner = prisonerRepository.findByNomsId("A4092EA")
-      assertThat(createdPrisoner).isNotNull()
+      Assertions.assertThat(createdPrisoner).isNotNull()
       val saved = offenderEventRepository.findAllByPrisonerId(createdPrisoner?.id!!)
-      assertThat(saved).hasSize(1)
-      assertThat(saved[0].reason).isNull()
+      Assertions.assertThat(saved).hasSize(1)
+      Assertions.assertThat(saved[0].reason).isNull()
     }
   }
 
@@ -102,12 +105,25 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
-      assertThat(savedOffenderEvent).hasSize(1)
-      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate").isEqualTo(OffenderEventEntity(id = UUID.randomUUID(), prisonerId = 1, nomsId = "A4092EA", type = OffenderEventType.PRISON_RELEASE, occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"), reason = null, reasonCode = "NCS", creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329")))
+      Assertions.assertThat(savedOffenderEvent).hasSize(1)
+      Assertions.assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
+        .isEqualTo(
+          OffenderEventEntity(
+            id = UUID.randomUUID(),
+            prisonerId = 1,
+            nomsId = "A4092EA",
+            type = OffenderEventType.PRISON_RELEASE,
+            occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"),
+            reason = null,
+            reasonCode = "NCS",
+            creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329"),
+          ),
+        )
 
       val savedPrisoner = prisonerRepository.findAll()
-      assertThat(savedPrisoner).hasSize(1)
-      assertThat(savedPrisoner[0]).isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
+      Assertions.assertThat(savedPrisoner).hasSize(1)
+      Assertions.assertThat(savedPrisoner[0])
+        .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
     }
   }
 
@@ -121,18 +137,31 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
-      assertThat(savedOffenderEvent).hasSize(1)
-      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate").isEqualTo(OffenderEventEntity(id = UUID.randomUUID(), prisonerId = 1, nomsId = "A4092EA", type = OffenderEventType.PRISON_RELEASE, occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"), reason = null, reasonCode = "NCS", creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329")))
+      Assertions.assertThat(savedOffenderEvent).hasSize(1)
+      Assertions.assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
+        .isEqualTo(
+          OffenderEventEntity(
+            id = UUID.randomUUID(),
+            prisonerId = 1,
+            nomsId = "A4092EA",
+            type = OffenderEventType.PRISON_RELEASE,
+            occurredAt = ZonedDateTime.parse("2024-12-11T15:43:20+00:00"),
+            reason = null,
+            reasonCode = "NCS",
+            creationDate = LocalDateTime.parse("2024-12-11T16:47:12.426329"),
+          ),
+        )
 
       val savedPrisoner = prisonerRepository.findAll()
-      assertThat(savedPrisoner).hasSize(1)
-      assertThat(savedPrisoner[0]).isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
+      Assertions.assertThat(savedPrisoner).hasSize(1)
+      Assertions.assertThat(savedPrisoner[0])
+        .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
 
       val savedCaseAllocation = caseAllocationRepository.findByPrisonerIdAndIsDeleted(1, true)
-      assertThat(savedCaseAllocation).isNotNull
-      assertThat(savedCaseAllocation?.id).isEqualTo(1)
-      assertThat(savedCaseAllocation?.isDeleted).isEqualTo(true)
-      assertThat(savedCaseAllocation?.deletionDate).isNotNull()
+      Assertions.assertThat(savedCaseAllocation).isNotNull
+      Assertions.assertThat(savedCaseAllocation?.id).isEqualTo(1)
+      Assertions.assertThat(savedCaseAllocation?.isDeleted).isEqualTo(true)
+      Assertions.assertThat(savedCaseAllocation?.deletionDate).isNotNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/events/OffenderEventsIntegrationTest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.ev
 
 import kotlinx.coroutines.future.await
 import kotlinx.coroutines.test.runTest
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.awaitility.kotlin.await
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -57,11 +57,11 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val saved = offenderEventRepository.findAllByPrisonerId(1)
-      Assertions.assertThat(saved).hasSize(1)
-      Assertions.assertThat(saved[0].reason).isEqualTo(MovementReasonType.RECALL)
+      assertThat(saved).hasSize(1)
+      assertThat(saved[0].reason).isEqualTo(MovementReasonType.RECALL)
     }
     val prisoner = prisonerRepository.getReferenceById(1)
-    Assertions.assertThat(prisoner.prisonId).describedAs { "Prison id should be updated" }.isEqualTo("SWI")
+    assertThat(prisoner.prisonId).describedAs { "Prison id should be updated" }.isEqualTo("SWI")
   }
 
   @Sql("classpath:testdata/sql/seed-prisoners-for-events.sql")
@@ -74,8 +74,8 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val saved = offenderEventRepository.findAllByPrisonerId(1)
-      Assertions.assertThat(saved).hasSize(1)
-      Assertions.assertThat(saved[0].reason).isNull()
+      assertThat(saved).hasSize(1)
+      assertThat(saved[0].reason).isNull()
     }
   }
 
@@ -88,10 +88,10 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val createdPrisoner = prisonerRepository.findByNomsId("A4092EA")
-      Assertions.assertThat(createdPrisoner).isNotNull()
+      assertThat(createdPrisoner).isNotNull()
       val saved = offenderEventRepository.findAllByPrisonerId(createdPrisoner?.id!!)
-      Assertions.assertThat(saved).hasSize(1)
-      Assertions.assertThat(saved[0].reason).isNull()
+      assertThat(saved).hasSize(1)
+      assertThat(saved[0].reason).isNull()
     }
   }
 
@@ -105,8 +105,8 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
-      Assertions.assertThat(savedOffenderEvent).hasSize(1)
-      Assertions.assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
+      assertThat(savedOffenderEvent).hasSize(1)
+      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
         .isEqualTo(
           OffenderEventEntity(
             id = UUID.randomUUID(),
@@ -121,8 +121,8 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
         )
 
       val savedPrisoner = prisonerRepository.findAll()
-      Assertions.assertThat(savedPrisoner).hasSize(1)
-      Assertions.assertThat(savedPrisoner[0])
+      assertThat(savedPrisoner).hasSize(1)
+      assertThat(savedPrisoner[0])
         .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
     }
   }
@@ -137,8 +137,8 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
 
     await.atMost(2.seconds.toJavaDuration()).untilAsserted {
       val savedOffenderEvent = offenderEventRepository.findAllByPrisonerId(1)
-      Assertions.assertThat(savedOffenderEvent).hasSize(1)
-      Assertions.assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
+      assertThat(savedOffenderEvent).hasSize(1)
+      assertThat(savedOffenderEvent[0]).usingRecursiveComparison().ignoringFields("id", "creationDate")
         .isEqualTo(
           OffenderEventEntity(
             id = UUID.randomUUID(),
@@ -153,15 +153,15 @@ class OffenderEventsIntegrationTest : IntegrationTestBase() {
         )
 
       val savedPrisoner = prisonerRepository.findAll()
-      Assertions.assertThat(savedPrisoner).hasSize(1)
-      Assertions.assertThat(savedPrisoner[0])
+      assertThat(savedPrisoner).hasSize(1)
+      assertThat(savedPrisoner[0])
         .isEqualTo(PrisonerEntity(1, "A4092EA", LocalDateTime.parse("2023-08-16T12:21:38.709"), "OUT"))
 
       val savedCaseAllocation = caseAllocationRepository.findByPrisonerIdAndIsDeleted(1, true)
-      Assertions.assertThat(savedCaseAllocation).isNotNull
-      Assertions.assertThat(savedCaseAllocation?.id).isEqualTo(1)
-      Assertions.assertThat(savedCaseAllocation?.isDeleted).isEqualTo(true)
-      Assertions.assertThat(savedCaseAllocation?.deletionDate).isNotNull()
+      assertThat(savedCaseAllocation).isNotNull
+      assertThat(savedCaseAllocation?.id).isEqualTo(1)
+      assertThat(savedCaseAllocation?.isDeleted).isEqualTo(true)
+      assertThat(savedCaseAllocation?.deletionDate).isNotNull()
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CaseNotesApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CaseNotesApiMockServer.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 class CaseNotesApiMockServer : WireMockServerBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CuriousApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CuriousApiMockServer.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wi
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 class CuriousApiMockServer : WireMockServerBase() {
   fun stubGetLearnerEducationListByNomsId(nomsId: String, status: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CvlApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/CvlApiMockServer.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 import java.util.Base64
 
 class CvlApiMockServer : WireMockServerBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/InterventionsServiceApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/InterventionsServiceApiMockServer.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wiremock
 import com.github.tomakehurst.wiremock.client.WireMock
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 class InterventionsServiceApiMockServer : WireMockServerBase() {
   fun stubGetCRSAppointmentsFromCRN(crn: String, status: Int) {
     val appointmentsListJSON = readFile("testdata/interventions-service-api/crs-appointments.json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/ManageUsersApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/ManageUsersApiMockServer.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wi
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 class ManageUsersApiMockServer : WireMockServerBase() {
   fun stubGetManageUsersData(prisonId: String, status: Int) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PoPUserApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PoPUserApiMockServer.kt
@@ -3,7 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wi
 import com.github.tomakehurst.wiremock.client.WireMock
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 class PoPUserApiMockServer : WireMockServerBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonApiMockServer.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.wi
 
 import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.get
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 import java.util.Base64
 
 class PrisonApiMockServer : WireMockServerBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 class PrisonerSearchApiMockServer : WireMockServerBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/ResettlementPassportDeliusApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/ResettlementPassportDeliusApiMockServer.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import com.github.tomakehurst.wiremock.client.WireMock.equalToJson
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 import java.time.LocalDate
 
 class ResettlementPassportDeliusApiMockServer : WireMockServerBase() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/WireMockServerBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/integration/wiremock/WireMockServerBase.kt
@@ -4,7 +4,7 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import com.github.tomakehurst.wiremock.client.ResponseDefinitionBuilder
 import com.github.tomakehurst.wiremock.client.WireMock
 import org.springframework.test.util.TestSocketUtils.findAvailableTcpPort
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 
 open class WireMockServerBase : WireMockServer(findAvailableTcpPort()) {
   fun stubGet(path: String, status: Int, jsonResponseFile: String?) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AdminServiceTest.kt
@@ -1,12 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import org.junit.jupiter.api.AfterAll
-import org.junit.jupiter.api.BeforeAll
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -16,12 +10,12 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearch
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.PrisonerSearchApiService
-import java.time.LocalDateTime
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)
 class AdminServiceTest {
-  private lateinit var adminService: AdminService
+  private val adminService by lazy { AdminService(telemetryClient, caseAllocationService, prisonerSearchApiService, prisonerService) }
 
   @Mock
   private lateinit var telemetryClient: TelemetryClient
@@ -34,29 +28,6 @@ class AdminServiceTest {
 
   @Mock
   private lateinit var prisonerService: PrisonerService
-
-  companion object {
-
-    private val fakeNow = LocalDateTime.parse("2024-07-02T12:12:12")
-
-    @JvmStatic
-    @BeforeAll
-    fun beforeAll() {
-      mockkStatic(LocalDateTime::class)
-      every { LocalDateTime.now() } returns fakeNow
-    }
-
-    @JvmStatic
-    @AfterAll
-    fun afterAll() {
-      unmockkAll()
-    }
-  }
-
-  @BeforeEach
-  fun beforeEach() {
-    adminService = AdminService(telemetryClient, caseAllocationService, prisonerSearchApiService, prisonerService)
-  }
 
   @Test
   fun `test sendMetricsToAppInsights`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/AssessmentServiceTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,6 +10,9 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Assessment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.AssessmentSkipReason
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.fakeNow
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.testDate
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.AssessmentSkipEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.IdTypeEntity
@@ -25,7 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import java.time.LocalDateTime
 import java.util.*
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)
 class AssessmentServiceTest {
   private lateinit var assessmentService: AssessmentService
 
@@ -40,8 +40,6 @@ class AssessmentServiceTest {
 
   @Mock
   private lateinit var idTypeRepository: IdTypeRepository
-  private val testDate = LocalDateTime.parse("2023-08-16T12:00:00")
-  private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
   @BeforeEach
   fun beforeEach() {
@@ -80,22 +78,16 @@ class AssessmentServiceTest {
 
   @Test
   fun `test deleteAssessment - sets deleted flag`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val assessmentEntity = AssessmentEntity(1, prisonerEntity.id(), fakeNow, fakeNow, isBankAccountRequired = true, isIdRequired = true, idDocuments = emptySet(), isDeleted = false, deletionDate = null)
     val expectedAssessmentEntity = AssessmentEntity(1, prisonerEntity.id(), fakeNow, fakeNow, isBankAccountRequired = true, isIdRequired = true, idDocuments = emptySet(), isDeleted = true, deletionDate = fakeNow)
 
     assessmentService.deleteAssessment(assessmentEntity)
     Mockito.verify(assessmentRepository).save(expectedAssessmentEntity)
-
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test createAssessment - creates assessment`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val nomsId = "abc"
     val prisonerEntity = PrisonerEntity(1, nomsId, testDate, "xyz")
     val idTypes = listOf(IdTypeEntity(1, "Driving licence"), IdTypeEntity(2, "Birth certificate"), IdTypeEntity(1, "Something else"))
@@ -108,8 +100,6 @@ class AssessmentServiceTest {
 
     assessmentService.createAssessment(assessment)
     Mockito.verify(assessmentRepository).save(expectedAssessmentEntity)
-
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationServiceTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -18,6 +15,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.Duplicat
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.ResourceNotFoundException
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.BankApplication
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.BankApplicationResponse
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.fakeNow
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.testDate
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.BankApplicationEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.BankApplicationStatusLogEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
@@ -25,11 +25,9 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.BankApplicationStatusLogRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.BankApplicationService.BankApplicationLogSarContent
-import java.time.LocalDateTime
 import java.util.*
-import kotlin.collections.emptyList
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)
 class BankApplicationServiceTest {
   private lateinit var bankApplicationService: BankApplicationService
 
@@ -41,8 +39,6 @@ class BankApplicationServiceTest {
 
   @Mock
   private lateinit var bankApplicationStatusLogRepository: BankApplicationStatusLogRepository
-  private val testDate = LocalDateTime.parse("2023-08-16T12:00:00")
-  private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
 
   @BeforeEach
   fun beforeEach() {
@@ -93,8 +89,6 @@ class BankApplicationServiceTest {
 
   @Test
   fun `test deleteBankApplication - updates isDeleted and deletionDate`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val bankApplicationEntity = BankApplicationEntity(1, prisonerEntity.id(), emptySet(), fakeNow, fakeNow, status = "Pending", bankName = "Lloyds")
     val expectedBankApplicationEntity = BankApplicationEntity(
@@ -112,13 +106,10 @@ class BankApplicationServiceTest {
     bankApplicationService.deleteBankApplication(bankApplicationEntity)
 
     Mockito.verify(bankApplicationRepository).save(expectedBankApplicationEntity)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test createBankApplication - creates bank application`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val bankApplication = BankApplication(applicationSubmittedDate = fakeNow, bankName = "Lloyds")
     val bankApplicationEntity = BankApplicationEntity(1, prisonerEntity.id(), setOf(BankApplicationStatusLogEntity(null, null, "Pending", fakeNow)), fakeNow, fakeNow, status = "Pending", isDeleted = false, bankName = "Lloyds")
@@ -132,13 +123,10 @@ class BankApplicationServiceTest {
     bankApplicationService.createBankApplication(bankApplication, prisonerEntity.nomsId, false)
 
     Mockito.verify(bankApplicationStatusLogRepository).save(expectedLogEntity)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test createBankApplication - creates bank application duplicate check`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val bankApplication = BankApplication(applicationSubmittedDate = fakeNow, bankName = "Lloyds")
     val bankApplicationEntity = BankApplicationEntity(1, prisonerEntity.id(), setOf(BankApplicationStatusLogEntity(null, null, "Pending", fakeNow)), fakeNow, fakeNow, status = "Pending", isDeleted = false, bankName = "Lloyds")
@@ -152,7 +140,6 @@ class BankApplicationServiceTest {
     Mockito.verify(bankApplicationStatusLogRepository).save(expectedLogEntity)
     assertThrows<DuplicateDataFoundException> { bankApplicationService.createBankApplication(bankApplication, prisonerEntity.nomsId, true) }
     Mockito.verify(bankApplicationRepository, Mockito.never()).save(Mockito.any())
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Nested
@@ -166,7 +153,7 @@ class BankApplicationServiceTest {
 
       val response = bankApplicationService.getBankApplicationsByPrisonerAndCreationDate(prisoner, fakeNow, fakeNow)
 
-      Assertions.assertEquals(emptyList<BankApplicationResponse>(), response)
+      Assertions.assertEquals(emptyList<BankApplicationService.BankApplicationSarContent>(), response)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/BankApplicationServiceTest.kt
@@ -26,7 +26,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PrisonerRepository
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.BankApplicationService.BankApplicationLogSarContent
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.BankApplicationService.BankApplicationSarContent
-import java.time.LocalDateTime
 import java.util.*
 
 @ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/CaseAllocationServiceTest.kt
@@ -1,13 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.mockk.unmockkStatic
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
@@ -21,6 +16,11 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseAlloca
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.CaseAllocationPostResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.manageusersapi.ManageUser
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearchList
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.fakeNow
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.testDate
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension.Companion.mockClaimFromJWTToken
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFileAsObject
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseAllocationEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
@@ -30,9 +30,18 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.externa
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.PrisonerSearchApiService
 import java.time.LocalDateTime
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, JWTTokenMockExtension::class)
 class CaseAllocationServiceTest {
-  private lateinit var caseAllocationService: CaseAllocationService
+  private val caseAllocationService by lazy {
+    CaseAllocationService(
+      prisonerRepository,
+      caseAllocationRepository,
+      manageUserApiService,
+      prisonerSearchApiService,
+      pathwayAndStatusService,
+      telemetryClient,
+    )
+  }
 
   @Mock
   private lateinit var prisonerRepository: PrisonerRepository
@@ -52,28 +61,9 @@ class CaseAllocationServiceTest {
   @Mock
   private lateinit var telemetryClient: TelemetryClient
 
-  private val testDate = LocalDateTime.parse("2023-08-16T12:00:00")
-  private val fakeNow = LocalDateTime.parse("2023-08-17T12:00:01")
-
-  @BeforeEach
-  fun beforeEach() {
-    caseAllocationService = CaseAllocationService(
-      prisonerRepository,
-      caseAllocationRepository,
-      manageUserApiService,
-      prisonerSearchApiService,
-      pathwayAndStatusService,
-      telemetryClient,
-    )
-  }
-
   @Test
   fun `test createCaseAllocation - creates and returns caseAllocation`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("auth", "sub") } returns "USERNAME"
-
+    mockClaimFromJWTToken()
     val manageUserList = emptyList<ManageUser>().toMutableList()
     val manageUser = ManageUser(4321, "PSO Firstname", "PSO Lastname")
     manageUserList.add(manageUser)
@@ -133,15 +123,11 @@ class CaseAllocationServiceTest {
       ),
       null,
     )
-    unmockkAll()
   }
 
   @Test
   fun `test removeCaseAllocation - unassign the allocation`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("auth", "sub") } returns "USERNAME"
+    mockClaimFromJWTToken()
 
     val caseList = emptyList<CaseAllocationEntity?>().toMutableList()
     val prisonerEntity = PrisonerEntity(1, "123", testDate, "xyz")
@@ -184,15 +170,11 @@ class CaseAllocationServiceTest {
       ),
       null,
     )
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test removeCaseAllocation - should ignore already unassigned prisoner while processing case unallocation request`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("auth", "sub") } returns "USERNAME"
+    mockClaimFromJWTToken()
 
     val expectedCaseList = emptyList<CaseAllocationEntity?>().toMutableList()
     val prisonerEntity1 = PrisonerEntity(1, "123", testDate, "xyz")
@@ -243,7 +225,6 @@ class CaseAllocationServiceTest {
       ),
       null,
     )
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/IdApplicationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/IdApplicationServiceTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,6 +10,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.IdApplicationPatch
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.IdApplicationPost
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.IdApplicationEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.IdTypeEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
@@ -22,7 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import java.math.BigDecimal
 import java.time.LocalDateTime
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)
 class IdApplicationServiceTest {
   private lateinit var idApplicationService: IdApplicationService
 
@@ -40,12 +39,11 @@ class IdApplicationServiceTest {
   @BeforeEach
   fun beforeEach() {
     idApplicationService = IdApplicationService(idApplicationRepository, prisonerRepository, idTypeRepository)
+    mockCurrentTime(fakeNow)
   }
 
   @Test
   fun `test createIdApplication - creates and returns idApplication`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val idTypeEntity = IdTypeEntity(1, "Drivers Licence")
     val idApplicationPost = IdApplicationPost(
@@ -86,13 +84,10 @@ class IdApplicationServiceTest {
     val result = idApplicationService.createIdApplication(idApplicationPost, prisonerEntity.nomsId)
     Mockito.verify(idApplicationRepository).save(idApplicationEntity)
     Assertions.assertEquals(idApplicationEntity, result)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test updateIdApplication - updates and returns idAppliaction`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val idTypeEntity = IdTypeEntity(1, "Drivers Licence")
     val idApplicationPatchDTO = IdApplicationPatch(
@@ -152,13 +147,10 @@ class IdApplicationServiceTest {
     val result = idApplicationService.updateIdApplication(idApplicationEntity, idApplicationPatchDTO)
     Mockito.verify(idApplicationRepository).save(expectedIdAssessment)
     Assertions.assertEquals(expectedIdAssessment, result)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test deleteIdApplication - sets is deleted and deletion date`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val idTypeEntity = IdTypeEntity(1, "Drivers Licence")
     val idApplicationEntity = IdApplicationEntity(
@@ -185,7 +177,6 @@ class IdApplicationServiceTest {
     idApplicationService.deleteIdApplication(idApplicationEntity)
 
     Mockito.verify(idApplicationRepository).save(expectedDeleteCall)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PathwayAndStatusServiceTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -18,6 +15,8 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.config.Resource
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Pathway
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PathwayAndStatus
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Status
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PathwayStatusEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PathwayStatusRepository
@@ -25,7 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.ResettlementPassportDeliusApiService
 import java.time.LocalDateTime
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class)
 class PathwayAndStatusServiceTest {
 
   private lateinit var pathwayAndStatusService: PathwayAndStatusService
@@ -49,14 +48,12 @@ class PathwayAndStatusServiceTest {
       prisonerRepository = prisonerRepository,
       transactionOperations = TransactionOperations.withoutTransaction(),
     )
+    // Mock calls to LocalDateTime.now() so we can test the updatedDate is being updated
+    mockCurrentTime(fakeNow)
   }
 
   @Test
   fun `test update pathway status`() {
-    // Mock calls to LocalDateTime.now() so we can test the updatedDate is being updated
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val nomsId = "abc"
     val prisonId = "xyz"
     val pathway = Pathway.ACCOMMODATION
@@ -73,8 +70,6 @@ class PathwayAndStatusServiceTest {
     val response = pathwayAndStatusService.updatePathwayStatus(nomsId, PathwayAndStatus(Pathway.ACCOMMODATION, Status.IN_PROGRESS))
     Assertions.assertEquals(HttpStatusCode.valueOf(200), response.statusCode)
     Mockito.verify(pathwayStatusRepository).save(expectedPathwayStatusEntity)
-
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PoPUserOTPServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PoPUserOTPServiceTest.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkStatic
-import io.opentelemetry.sdk.testing.assertj.OpenTelemetryAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -19,6 +16,10 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.PoPUserRes
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.popuserapi.KnowledgeBasedVerification
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.popuserapi.OneLoginData
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearch
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.ServiceUtilsMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.ServiceUtilsMockExtension.Companion.mockRandomAlphaNumericString
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PoPUserOTPEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.repository.PoPUserOTPRepository
@@ -30,9 +31,9 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
 
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, ServiceUtilsMockExtension::class)
 class PoPUserOTPServiceTest {
-  private lateinit var popUserOTPService: PoPUserOTPService
+  private val popUserOTPService by lazy { PoPUserOTPService(popUserOTPRepository, prisonerRepository, popUserApiService, prisonerSearchApiService, resettlementPassportDeliusApiService) }
 
   @Mock
   private lateinit var popUserOTPRepository: PoPUserOTPRepository
@@ -54,8 +55,7 @@ class PoPUserOTPServiceTest {
 
   @BeforeEach
   fun beforeEach() {
-    popUserOTPService =
-      PoPUserOTPService(popUserOTPRepository, prisonerRepository, popUserApiService, prisonerSearchApiService, resettlementPassportDeliusApiService)
+    mockCurrentTime(fakeNow)
   }
 
   @Test
@@ -86,8 +86,6 @@ class PoPUserOTPServiceTest {
 
   @Test
   fun `test delete PoPUserOTP - hard delete`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val prisonerEntity = PrisonerEntity(1, "acb", testDate, "xyz")
     val popUserOTPEntity = PoPUserOTPEntity(
       null,
@@ -101,7 +99,6 @@ class PoPUserOTPServiceTest {
     popUserOTPService.deletePoPUserOTP(popUserOTPEntity)
 
     Mockito.verify(popUserOTPRepository).delete(popUserOTPEntity)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
@@ -126,12 +123,7 @@ class PoPUserOTPServiceTest {
 
   @Test
   fun `test create Pop User OTP - creates and returns PoP User OTP`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-    mockkStatic(::randomAlphaNumericString)
-    every {
-      randomAlphaNumericString()
-    } returns "1X3456"
+    mockRandomAlphaNumericString("1X3456")
     val prisonerEntity = PrisonerEntity(1, "acb", fakeNow, "xyz")
     val popUserOTPEntity = PoPUserOTPEntity(
       null,
@@ -159,13 +151,10 @@ class PoPUserOTPServiceTest {
     whenever(prisonerSearchApiService.findPrisonerPersonalDetails(prisonerEntity.nomsId)).thenReturn(prisonerResponse)
     val result = popUserOTPService.createPoPUserOTP(prisonerEntity)
     Assertions.assertEquals(popUserOTPEntity.id, result.id)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test create Pop User Verified - Fails OTP Invalid`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val oneLoginData = OneLoginData("urn1", "123457", "email@test.com", LocalDate.parse("1982-10-24"))
     whenever(
       popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(
@@ -176,13 +165,10 @@ class PoPUserOTPServiceTest {
     ).thenReturn(null)
     val thrown = assertThrows<ResourceNotFoundException> { popUserOTPService.getPoPUserVerified(oneLoginData) }
     Assertions.assertEquals("Person On Probation User otp  123457  not found in database or expired.", thrown.message)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test create Pop User Verified -  valid OTP`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val oneLoginUserData = OneLoginData("urn1", "123457", "email@test.com", LocalDate.parse("1982-10-24"))
     val prisoner = PrisonerEntity(1, "acb", fakeNow, "xyz")
     val popUserResponse = PoPUserResponse(1, "crn1", "NA", true, fakeNow, fakeNow, "GU1234", "urn1")
@@ -220,7 +206,6 @@ class PoPUserOTPServiceTest {
     val result = popUserOTPService.getPoPUserVerified(oneLoginUserData)
     Mockito.verify(popUserOTPRepository).delete(popUserOTPEntity)
     Assertions.assertEquals(popUserResponse, result)
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
@@ -236,8 +221,6 @@ class PoPUserOTPServiceTest {
 
   @Test
   fun `test create Pop User Verified - Fails OTP Expired`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val oneLoginData = OneLoginData("urn1", "123457", "email@test.com", LocalDate.parse("1982-10-24"))
     Mockito.lenient().`when`(
       popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(
@@ -247,20 +230,16 @@ class PoPUserOTPServiceTest {
       ),
     ).thenReturn(null)
     assertThrows<ResourceNotFoundException> { popUserOTPService.getPoPUserVerified(oneLoginData) }
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test
   fun `test create Pop User Verified - Fails DOB not match`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
     val oneLoginData = OneLoginData("urn1", "123457", "email@test.com", LocalDate.parse("1982-10-24"))
     val dob = testDate.toLocalDate()
     Mockito.lenient()
-      .`when`(popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(oneLoginData.otp ?: "0", dob, testDate))
+      .`when`(popUserOTPRepository.findByOtpAndDobAndExpiryDateIsGreaterThan(oneLoginData.otp, dob, testDate))
       .thenReturn(null)
     assertThrows<ResourceNotFoundException> { popUserOTPService.getPoPUserVerified(oneLoginData) }
-    unmockkStatic(LocalDateTime::class)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
@@ -92,6 +92,7 @@ class PrisonerServiceTest {
   @Mock
   private lateinit var resettlementAssessmentService: ResettlementAssessmentService
 
+  private val auth = "123"
   private val jwtToken = "123"
   private val claimValue = "ABC11D"
   private val testDate = LocalDate.of(2024, 8, 5)
@@ -142,7 +143,7 @@ class PrisonerServiceTest {
       prisonerService.getPrisonerDetailsByNomsId(
         expectedPrisonerId,
         false,
-        jwtToken,
+        auth,
       )
     Assertions.assertTrue(prisoner.personalDetails?.isHomeDetention!!)
   }
@@ -169,7 +170,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        jwtToken,
+        auth,
         null,
       )
 
@@ -272,7 +273,7 @@ class PrisonerServiceTest {
         pageSize = 10,
         sort = "releaseDate,DESC",
         includePastReleaseDates = true,
-        auth = jwtToken,
+        auth = auth,
         null,
       )
 
@@ -564,7 +565,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        jwtToken,
+        auth,
         null,
       )
 
@@ -593,7 +594,7 @@ class PrisonerServiceTest {
         20,
         "releaseDate,ASC",
         false,
-        jwtToken,
+        auth,
         null,
       )
     Assertions.assertEquals(
@@ -625,7 +626,7 @@ class PrisonerServiceTest {
         10,
         "name,ASC",
         false,
-        jwtToken,
+        auth,
         null,
       )
     Assertions.assertEquals(expectedPrisonerId, prisonersList.content?.get(0)?.prisonerNumber ?: 0)
@@ -642,7 +643,7 @@ class PrisonerServiceTest {
     whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
-      prisonerService.getPrisonersByPrisonId("", prisonId, 0, null, null, null, 0, 5, "name,ASC", false, jwtToken, null)
+      prisonerService.getPrisonersByPrisonId("", prisonId, 0, null, null, null, 0, 5, "name,ASC", false, auth, null)
     Assertions.assertEquals(expectedPageSize, prisonersList.pageSize)
     prisonersList.content?.toList()?.let { Assertions.assertEquals(expectedPageSize, it.size) }
   }
@@ -670,7 +671,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        jwtToken,
+        auth,
         null,
       )
 
@@ -738,7 +739,7 @@ class PrisonerServiceTest {
         10,
         "name,ASC",
         false,
-        jwtToken,
+        auth,
         null,
       )
     Assertions.assertEquals(expectedPrisonerId, prisonersList.content?.get(0)?.prisonerNumber ?: 0)
@@ -764,7 +765,7 @@ class PrisonerServiceTest {
       10,
       "releaseDate,DESC",
       false,
-      jwtToken,
+      auth,
       null,
     )
 
@@ -791,7 +792,7 @@ class PrisonerServiceTest {
       10,
       "releaseDate,DESC",
       false,
-      jwtToken,
+      auth,
       null,
     )
 
@@ -1217,7 +1218,7 @@ class PrisonerServiceTest {
         "HDCED",
       ),
     )
-    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, jwtToken, null)
+    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, auth, null)
     Assertions.assertEquals(prisonersMapped, actualPrisoners)
   }
 
@@ -1228,7 +1229,7 @@ class PrisonerServiceTest {
     mockPathwayStatusEntities()
     whenever(caseAllocationService.getAllAssignedResettlementWorkers("MDI")).thenReturn(createCaseAllocationList())
 
-    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, jwtToken, workerId)
+    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, auth, workerId)
     Assertions.assertEquals(expectedPrisoners.size, actualPrisoners.size)
     Assertions.assertEquals(expectedPrisoners, actualPrisoners)
   }
@@ -1366,7 +1367,7 @@ class PrisonerServiceTest {
     val filteredPrisoners = prisonerService.objectMapper(
       searchList = allPrisoners,
       prisonId = "MDI",
-      staffUsername = "123",
+      staffUsername = auth,
       lastReportCompleted = lastReportCompleted,
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/PrisonerServiceTest.kt
@@ -1,9 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -27,9 +23,15 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.Status
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearch
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearchList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentStatus
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateMockExtension.Companion.mockCurrentDate
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension.Companion.mockClaimFromJWTToken
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFileAsObject
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readStringAsObject
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.CaseAllocationEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PathwayStatusEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
@@ -44,11 +46,12 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.externa
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.ResettlementPassportDeliusApiService
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, CurrentDateMockExtension::class, JWTTokenMockExtension::class)
 class PrisonerServiceTest {
 
   private lateinit var prisonerService: PrisonerService
@@ -89,6 +92,11 @@ class PrisonerServiceTest {
   @Mock
   private lateinit var resettlementAssessmentService: ResettlementAssessmentService
 
+  private val jwtToken = "123"
+  private val claimValue = "ABC11D"
+  private val testDate = LocalDate.of(2024, 8, 5)
+  private val fakeNow = LocalDateTime.of(testDate, LocalTime.of(0, 0, 0))
+
   @BeforeEach
   fun beforeEach() {
     prisonerService = PrisonerService(
@@ -105,13 +113,9 @@ class PrisonerServiceTest {
       supportNeedsService,
       resettlementAssessmentService,
     )
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("123", "sub") } returns "ABC11D"
-  }
-
-  @AfterEach
-  fun afterEach() {
-    unmockkAll()
+    mockClaimFromJWTToken(jwtToken, claimValue)
+    mockCurrentDate(testDate)
+    mockCurrentTime(fakeNow)
   }
 
   @Test
@@ -120,7 +124,7 @@ class PrisonerServiceTest {
     val expectedPrisonerId = "A8339DY"
     val mockEntity = PrisonerEntity(
       nomsId = expectedPrisonerId,
-      creationDate = LocalDateTime.now(),
+      creationDate = fakeNow,
       prisonId = "MDI",
       id = 1L,
     )
@@ -138,7 +142,7 @@ class PrisonerServiceTest {
       prisonerService.getPrisonerDetailsByNomsId(
         expectedPrisonerId,
         false,
-        "123",
+        jwtToken,
       )
     Assertions.assertTrue(prisoner.personalDetails?.isHomeDetention!!)
   }
@@ -165,7 +169,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        "123",
+        jwtToken,
         null,
       )
 
@@ -178,10 +182,10 @@ class PrisonerServiceTest {
           lastName = "CRD-LR-TEST",
           releaseDate = null,
           releaseType = "PRRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = null,
@@ -200,10 +204,10 @@ class PrisonerServiceTest {
           lastName = "CRAWFIS",
           releaseDate = LocalDate.parse("2099-09-12"),
           releaseType = "CRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
@@ -222,10 +226,10 @@ class PrisonerServiceTest {
           lastName = "MCVEIGH",
           releaseDate = LocalDate.parse("2099-08-01"),
           releaseType = "CRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = LocalDate.parse("2021-02-03"),
@@ -268,7 +272,7 @@ class PrisonerServiceTest {
         pageSize = 10,
         sort = "releaseDate,DESC",
         includePastReleaseDates = true,
-        auth = "123",
+        auth = jwtToken,
         null,
       )
 
@@ -281,10 +285,10 @@ class PrisonerServiceTest {
           lastName = "CRD-LR-TEST",
           releaseDate = null,
           releaseType = "PRRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = null,
@@ -303,10 +307,10 @@ class PrisonerServiceTest {
           lastName = "CRAWFIS",
           releaseDate = LocalDate.parse("2099-09-12"),
           releaseType = "CRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
@@ -325,10 +329,10 @@ class PrisonerServiceTest {
           lastName = "MCVEIGH",
           releaseDate = LocalDate.parse("2099-08-01"),
           releaseType = "CRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = LocalDate.parse("2021-02-03"),
@@ -560,7 +564,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        "123",
+        jwtToken,
         null,
       )
 
@@ -589,7 +593,7 @@ class PrisonerServiceTest {
         20,
         "releaseDate,ASC",
         false,
-        "123",
+        jwtToken,
         null,
       )
     Assertions.assertEquals(
@@ -621,7 +625,7 @@ class PrisonerServiceTest {
         10,
         "name,ASC",
         false,
-        "123",
+        jwtToken,
         null,
       )
     Assertions.assertEquals(expectedPrisonerId, prisonersList.content?.get(0)?.prisonerNumber ?: 0)
@@ -638,7 +642,7 @@ class PrisonerServiceTest {
     whenever(prisonerSearchApiService.findPrisonersBySearchTerm(prisonId, "")).thenReturn(mockedJsonResponse.content)
 
     val prisonersList =
-      prisonerService.getPrisonersByPrisonId("", prisonId, 0, null, null, null, 0, 5, "name,ASC", false, "123", null)
+      prisonerService.getPrisonersByPrisonId("", prisonId, 0, null, null, null, 0, 5, "name,ASC", false, jwtToken, null)
     Assertions.assertEquals(expectedPageSize, prisonersList.pageSize)
     prisonersList.content?.toList()?.let { Assertions.assertEquals(expectedPageSize, it.size) }
   }
@@ -666,7 +670,7 @@ class PrisonerServiceTest {
         10,
         "releaseDate,DESC",
         false,
-        "123",
+        jwtToken,
         null,
       )
 
@@ -679,10 +683,10 @@ class PrisonerServiceTest {
           lastName = "CRAWFIS",
           releaseDate = LocalDate.parse("2099-09-12"),
           releaseType = "CRD",
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           status = listOf(
-            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
-            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()),
+            PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate),
+            PathwayStatus(pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY, status = Status.NOT_STARTED, lastDateChange = testDate),
           ),
           pathwayStatus = null,
           homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
@@ -712,7 +716,7 @@ class PrisonerServiceTest {
     val expectedPrisonerId = "G1458GV"
     val days = 84
     val pattern = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-    val releaseDate = LocalDate.now().minusDays(days.toLong())
+    val releaseDate = testDate.minusDays(days.toLong())
 
     var mockedJsonResponseString = readFile("testdata/prisoner-search-api/prisoner-search-1.json")
     mockedJsonResponseString = mockedJsonResponseString.replace(
@@ -734,7 +738,7 @@ class PrisonerServiceTest {
         10,
         "name,ASC",
         false,
-        "123",
+        jwtToken,
         null,
       )
     Assertions.assertEquals(expectedPrisonerId, prisonersList.content?.get(0)?.prisonerNumber ?: 0)
@@ -760,7 +764,7 @@ class PrisonerServiceTest {
       10,
       "releaseDate,DESC",
       false,
-      "123",
+      jwtToken,
       null,
     )
 
@@ -787,7 +791,7 @@ class PrisonerServiceTest {
       10,
       "releaseDate,DESC",
       false,
-      "123",
+      jwtToken,
       null,
     )
 
@@ -795,45 +799,45 @@ class PrisonerServiceTest {
   }
 
   private fun mockDatabaseCalls(mockFindByPrison: Boolean = true) {
-    val mockPathwayStatusEntities = listOf(
-      aPrisonerWithStatusResult(
-        prisonerId = 1,
-        nomsId = "G1458GV",
-        pathway = Pathway.ACCOMMODATION,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-      aPrisonerWithStatusResult(
-        prisonerId = 1,
-        nomsId = "G1458GV",
-        pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-      aPrisonerWithStatusResult(
-        prisonerId = 2,
-        nomsId = "A8339DY",
-        pathway = Pathway.ACCOMMODATION,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-      aPrisonerWithStatusResult(
-        prisonerId = 2,
-        nomsId = "A8339DY",
-        pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-      aPrisonerWithStatusResult(
-        prisonerId = 3,
-        nomsId = "A8229DY",
-        pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-      aPrisonerWithStatusResult(
-        prisonerId = 3,
-        nomsId = "A8229DY",
-        pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
-        pathwayStatus = Status.NOT_STARTED,
-      ),
-    )
     if (mockFindByPrison) {
+      val mockPathwayStatusEntities = listOf(
+        aPrisonerWithStatusResult(
+          prisonerId = 1,
+          nomsId = "G1458GV",
+          pathway = Pathway.ACCOMMODATION,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+        aPrisonerWithStatusResult(
+          prisonerId = 1,
+          nomsId = "G1458GV",
+          pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+        aPrisonerWithStatusResult(
+          prisonerId = 2,
+          nomsId = "A8339DY",
+          pathway = Pathway.ACCOMMODATION,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+        aPrisonerWithStatusResult(
+          prisonerId = 2,
+          nomsId = "A8339DY",
+          pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+        aPrisonerWithStatusResult(
+          prisonerId = 3,
+          nomsId = "A8229DY",
+          pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+        aPrisonerWithStatusResult(
+          prisonerId = 3,
+          nomsId = "A8229DY",
+          pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
+          pathwayStatus = Status.NOT_STARTED,
+        ),
+      )
       whenever(pathwayStatusRepository.findByPrison(any())).thenReturn(mockPathwayStatusEntities)
     }
   }
@@ -843,7 +847,7 @@ class PrisonerServiceTest {
     override val nomsId = nomsId
     override val pathway = pathway
     override var pathwayStatus = pathwayStatus
-    override var updatedDate = LocalDateTime.now()
+    override var updatedDate = fakeNow
   }
 
   private fun mockDatabaseCallsForPathwayView() {
@@ -881,17 +885,17 @@ class PrisonerServiceTest {
         lastName = "CRD-LR-TEST",
         releaseDate = null,
         releaseType = "PRRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = listOf(
           PathwayStatus(
             pathway = Pathway.ACCOMMODATION,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
           PathwayStatus(
             pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
         ),
         pathwayStatus = null,
@@ -910,17 +914,17 @@ class PrisonerServiceTest {
         lastName = "MCVEIGH",
         releaseDate = LocalDate.parse("2099-08-01"),
         releaseType = "CRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = listOf(
           PathwayStatus(
             pathway = Pathway.ATTITUDES_THINKING_AND_BEHAVIOUR,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
           PathwayStatus(
             pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
         ),
         pathwayStatus = null,
@@ -939,17 +943,17 @@ class PrisonerServiceTest {
         lastName = "CRAWFIS",
         releaseDate = LocalDate.parse("2098-09-12"),
         releaseType = "CRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = listOf(
           PathwayStatus(
             pathway = Pathway.ACCOMMODATION,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
           PathwayStatus(
             pathway = Pathway.CHILDREN_FAMILIES_AND_COMMUNITY,
             status = Status.NOT_STARTED,
-            lastDateChange = LocalDate.now(),
+            lastDateChange = testDate,
           ),
         ),
         pathwayStatus = null,
@@ -979,7 +983,7 @@ class PrisonerServiceTest {
         lastName = "CRD-LR-TEST",
         releaseDate = null,
         releaseType = "PRRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = null,
         pathwayStatus = Status.DONE,
         homeDetentionCurfewEligibilityDate = null,
@@ -997,7 +1001,7 @@ class PrisonerServiceTest {
         lastName = "MCVEIGH",
         releaseDate = LocalDate.parse("2099-08-01"),
         releaseType = "CRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = null,
         pathwayStatus = Status.NOT_STARTED,
         homeDetentionCurfewEligibilityDate = LocalDate.parse("2021-02-03"),
@@ -1015,7 +1019,7 @@ class PrisonerServiceTest {
         lastName = "CRAWFIS",
         releaseDate = LocalDate.parse("2098-09-12"),
         releaseType = "CRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = null,
         pathwayStatus = Status.SUPPORT_DECLINED,
         homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
@@ -1044,7 +1048,7 @@ class PrisonerServiceTest {
         lastName = "CRAWFIS",
         releaseDate = LocalDate.parse("2098-09-12"),
         releaseType = "CRD",
-        lastUpdatedDate = LocalDate.now(),
+        lastUpdatedDate = testDate,
         status = null,
         pathwayStatus = Status.SUPPORT_DECLINED,
         homeDetentionCurfewEligibilityDate = LocalDate.parse("2018-10-16"),
@@ -1213,7 +1217,7 @@ class PrisonerServiceTest {
         "HDCED",
       ),
     )
-    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, "123", null)
+    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, jwtToken, null)
     Assertions.assertEquals(prisonersMapped, actualPrisoners)
   }
 
@@ -1224,7 +1228,7 @@ class PrisonerServiceTest {
     mockPathwayStatusEntities()
     whenever(caseAllocationService.getAllAssignedResettlementWorkers("MDI")).thenReturn(createCaseAllocationList())
 
-    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, "123", workerId)
+    val actualPrisoners = prisonerService.objectMapper(prisoners, null, null, "MDI", null, jwtToken, workerId)
     Assertions.assertEquals(expectedPrisoners.size, actualPrisoners.size)
     Assertions.assertEquals(expectedPrisoners, actualPrisoners)
   }
@@ -1240,9 +1244,9 @@ class PrisonerServiceTest {
           assignedWorkerFirstname = "firstName1",
           assignedWorkerLastname = "lastName1",
           assessmentRequired = true,
-          lastUpdatedDate = LocalDate.now(),
+          lastUpdatedDate = testDate,
           pathwayStatus = null,
-          status = listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now())),
+          status = listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate)),
           needs = listOf(),
           lastReport = null,
         )
@@ -1289,10 +1293,10 @@ class PrisonerServiceTest {
             null
           },
           assessmentRequired = true,
-          lastUpdatedDate = if (i < 3) LocalDate.now() else null,
+          lastUpdatedDate = if (i < 3) testDate else null,
           pathwayStatus = null,
           status = if (i < 3) {
-            listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()))
+            listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate))
           } else {
             enumValues<Pathway>().map { pathway -> PathwayStatus(pathway = pathway, status = Status.NOT_STARTED) }
           },
@@ -1323,10 +1327,10 @@ class PrisonerServiceTest {
             null
           },
           assessmentRequired = true,
-          lastUpdatedDate = if (i < 3) LocalDate.now() else null,
+          lastUpdatedDate = if (i < 3) testDate else null,
           pathwayStatus = null,
           status = if (i < 3) {
-            listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = LocalDate.now()))
+            listOf(PathwayStatus(pathway = Pathway.ACCOMMODATION, status = Status.NOT_STARTED, lastDateChange = testDate))
           } else {
             enumValues<Pathway>().map { pathway -> PathwayStatus(pathway = pathway, status = Status.NOT_STARTED) }
           },
@@ -2131,15 +2135,14 @@ class PrisonerServiceTest {
   @ParameterizedTest(name = "{0}")
   @MethodSource("test processReleaseDateFiltering data")
   fun `test processReleaseDateFiltering`(desc: String, days: Int, prisoners: MutableList<PrisonersSearch>, includePastReleaseDates: Boolean, expectedList: List<PrisonersSearch>) {
-    mockkStatic(LocalDate::class)
-    every { LocalDate.now() } returns LocalDate.parse("2024-08-05")
-
     prisonerService.processReleaseDateFiltering(days, prisoners, includePastReleaseDates)
     Assertions.assertEquals(expectedList.map { it.displayReleaseDate }, prisoners.map { it.displayReleaseDate })
-
-    unmockkAll()
   }
 
+  /**
+   * @see uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateMockExtension
+   */
+  @Suppress("unused")
   private fun `test processReleaseDateFiltering data`() = Stream.of(
     // Note - "now" is set to 2024-08-05 in this test.
     Arguments.of(
@@ -2222,7 +2225,7 @@ class PrisonerServiceTest {
 
   @Test
   fun `test getPrisonerReleaseDateByNomsId`() {
-    val nomsId = "123"
+    val nomsId = "A123456"
     whenever(prisonerSearchApiService.findPrisonerPersonalDetails(nomsId)).thenReturn(
       PrisonersSearch(
         prisonerNumber = "A123456",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/ResettlementAssessmentServiceTest.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.apache.commons.lang3.RandomStringUtils
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
@@ -43,6 +40,10 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettleme
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentStatus
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentSubmitResponse
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.StringAnswer
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension.Companion.mockClaimFromJWTToken
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ProfileTagsEntity
@@ -68,7 +69,7 @@ import java.time.LocalDateTime
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, JWTTokenMockExtension::class)
 class ResettlementAssessmentServiceTest {
   private lateinit var resettlementAssessmentService: ResettlementAssessmentService
 
@@ -136,6 +137,8 @@ class ResettlementAssessmentServiceTest {
       prisonerSearchApiService,
       telemetryClient,
     )
+
+    mockCurrentTime(fakeNow)
   }
 
   private fun getTestConfig() = ResettlementAssessmentConfig().assessmentQuestionSets(
@@ -737,9 +740,6 @@ class ResettlementAssessmentServiceTest {
 
   @Test
   fun `test deleteAllResettlementAssessments - happy path`() {
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
-
     val nomsId = "12345"
     val prisonerId = 1L
 
@@ -766,8 +766,6 @@ class ResettlementAssessmentServiceTest {
     verify(resettlementAssessmentRepository).findAllByPrisonerIdAndDeletedIsFalse(prisonerId)
     verify(resettlementAssessmentRepository).save(deletedResettlementAssessmentEntity1)
     verify(resettlementAssessmentRepository).save(deletedResettlementAssessmentEntity2)
-
-    unmockkAll()
   }
 
   @Test
@@ -970,10 +968,9 @@ class ResettlementAssessmentServiceTest {
     val crn = "CRN1"
     val prisonCode = "MDI"
 
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns "A User"
-    every { getClaimFromJWTToken(auth, "sub") } returns "A_USER"
-    every { getClaimFromJWTToken(auth, "auth_source") } returns "nomis"
+    mockClaimFromJWTToken(token = auth, claimValue = "A User", claimName = "name")
+    mockClaimFromJWTToken(token = auth, claimValue = "A_USER", claimName = "sub")
+    mockClaimFromJWTToken(token = auth, claimValue = "nomis", claimName = "auth_source")
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(PrisonerEntity(id = 1, nomsId = nomsId, prisonId = prisonCode))
     Pathway.entries.forEachIndexed { i, pathway ->
@@ -1008,8 +1005,6 @@ class ResettlementAssessmentServiceTest {
     Assertions.assertEquals(ResettlementAssessmentSubmitResponse(false), response)
 
     verify(telemetryClient).trackEvent("PSFR_ReportSubmitted", mapOf("reportType" to assessmentType.name, "prisonId" to prisonCode, "prisonerId" to nomsId, "submittedBy" to "A_USER", "authSource" to "nomis"), null)
-
-    unmockkAll()
   }
 
   @Test
@@ -1022,10 +1017,9 @@ class ResettlementAssessmentServiceTest {
     val jwtTokenName = "A User"
     val jwtTokenSub = "A_USER"
 
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns jwtTokenName
-    every { getClaimFromJWTToken(auth, "sub") } returns jwtTokenSub
-    every { getClaimFromJWTToken(auth, "auth_source") } returns "nomis"
+    mockClaimFromJWTToken(token = auth, claimValue = jwtTokenName, claimName = "name")
+    mockClaimFromJWTToken(token = auth, claimValue = jwtTokenSub, claimName = "sub")
+    mockClaimFromJWTToken(token = auth, claimValue = "nomis", claimName = "auth_source")
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(PrisonerEntity(id = 1, nomsId = nomsId, prisonId = prisonCode))
     Pathway.entries.forEachIndexed { i, pathway ->
@@ -1062,8 +1056,6 @@ class ResettlementAssessmentServiceTest {
     val expectedContentOnlyDpsCaseNote = toContentOnlyDpsCaseNote(jwtTokenName, jwtTokenSub, assessmentType)
 
     verify(telemetryClient).trackEvent("PSFR_ReportDeliusCaseNoteSubmissionFailure", mapOf("reportType" to expectedContentOnlyDpsCaseNote.deliusCaseNoteType.name, "prisonId" to prisonCode, "prisonerId" to nomsId, "user" to jwtTokenSub, "authSource" to "nomis"), null)
-
-    unmockkAll()
   }
 
   private fun toContentOnlyDpsCaseNote(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/SupportNeedsServiceTest.kt
@@ -1,9 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service
 
 import com.microsoft.applicationinsights.TelemetryClient
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -39,6 +36,10 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNee
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNeeds
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.SupportNeedsUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.prisonersapi.PrisonersSearch
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension.Companion.mockClaimFromJWTToken
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerSupportNeedUpdateEntity
@@ -55,7 +56,7 @@ import java.util.*
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, JWTTokenMockExtension::class)
 class SupportNeedsServiceTest {
   private lateinit var supportNeedsService: SupportNeedsService
 
@@ -788,13 +789,11 @@ class SupportNeedsServiceTest {
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(PrisonerEntity(id = 1, nomsId = nomsId, creationDate = LocalDateTime.parse("2025-01-28T12:09:34"), prisonId = "MDI"))
 
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns "A User"
-    every { getClaimFromJWTToken(auth, "sub") } returns "A_USER"
-    every { getClaimFromJWTToken(auth, "auth_source") } returns "nomis"
+    mockClaimFromJWTToken(token = auth, claimValue = "A User", claimName = "name")
+    mockClaimFromJWTToken(token = auth, claimValue = "A_USER", claimName = "sub")
+    mockClaimFromJWTToken(token = auth, claimValue = "nomis", claimName = "auth_source")
 
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     whenever(prisonerSupportNeedRepository.findFirstByPrisonerIdAndSupportNeedIdAndOtherDetailAndDeletedIsFalseOrderByCreatedDateDesc(1, 8, null)).thenReturn(null)
     whenever(supportNeedRepository.findByIdAndDeletedIsFalse(8)).thenReturn(getSupportNeed(8, Pathway.HEALTH))
@@ -808,8 +807,6 @@ class SupportNeedsServiceTest {
     verify(prisonerSupportNeedRepository).save(PrisonerSupportNeedEntity(id = 9, prisonerId = 1, supportNeed = getSupportNeed(8, Pathway.HEALTH), otherDetail = null, createdBy = "A User", createdDate = fakeNow, latestUpdateId = 12))
 
     verify(telemetryClient).trackEvent("PSFR_SupportNeedsSubmitted", mapOf("supportNeedIds" to "[8]", "prisonId" to "MDI", "prisonerId" to "A123", "submittedBy" to "A_USER", "authSource" to "nomis"), null)
-
-    unmockkAll()
   }
 
   @Test
@@ -826,26 +823,22 @@ class SupportNeedsServiceTest {
     val auth = "auth"
     val fakeNow = LocalDateTime.parse("2025-01-31T12:00:01")
 
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns "A User"
-    every { getClaimFromJWTToken(auth, "sub") } returns "A_USER"
-    every { getClaimFromJWTToken(auth, "auth_source") } returns "nomis"
+    mockClaimFromJWTToken(token = auth, claimValue = "A User", claimName = "name")
+    mockClaimFromJWTToken(token = auth, claimValue = "A_USER", claimName = "sub")
+    mockClaimFromJWTToken(token = auth, claimValue = "nomis", claimName = "auth_source")
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(PrisonerEntity(id = 1, nomsId = nomsId, creationDate = LocalDateTime.parse("2025-01-28T12:09:34"), prisonId = "MDI"))
     whenever(prisonerSupportNeedRepository.findByIdAndDeletedIsFalse(prisonerNeedId)).thenReturn(PrisonerSupportNeedEntity(prisonerId = 1, supportNeed = getSupportNeed(8, Pathway.HEALTH), otherDetail = null, createdBy = "A User", createdDate = fakeNow))
     whenever(prisonerSupportNeedUpdateRepository.save(PrisonerSupportNeedUpdateEntity(prisonerSupportNeedId = 1234L, createdBy = "A User", createdDate = fakeNow, updateText = "Some support need text", status = SupportNeedStatus.IN_PROGRESS, isPrison = true, isProbation = false))).thenReturn(PrisonerSupportNeedUpdateEntity(id = 567, prisonerSupportNeedId = 123L, createdBy = "A User", createdDate = fakeNow, updateText = "Some support need text", status = SupportNeedStatus.IN_PROGRESS, isPrison = true, isProbation = false))
     stubPrisonerDetails(nomsId)
 
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     supportNeedsService.patchPrisonerNeedById(nomsId, prisonerNeedId, supportNeedsUpdateRequest, auth)
 
     verify(prisonerSupportNeedRepository).save(PrisonerSupportNeedEntity(prisonerId = 1, latestUpdateId = 567, supportNeed = getSupportNeed(8, Pathway.HEALTH), otherDetail = null, createdBy = "A User", createdDate = fakeNow))
 
     verify(telemetryClient).trackEvent("PSFR_SupportNeedUpdated", mapOf("prisonerSupportNeedId" to "1234", "supportNeedId" to "8", "prisonId" to "MDI", "prisonerId" to "A123", "submittedBy" to "A_USER", "authSource" to "nomis"), null)
-
-    unmockkAll()
   }
 
   @Test
@@ -880,8 +873,7 @@ class SupportNeedsServiceTest {
       status = SupportNeedStatus.IN_PROGRESS,
     )
     val auth = "auth"
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns "A User"
+    mockClaimFromJWTToken(token = auth, claimValue = "A User", claimName = "name")
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(
       PrisonerEntity(id = 1, nomsId = nomsId, creationDate = LocalDateTime.now(), prisonId = "MDI"),
@@ -906,8 +898,7 @@ class SupportNeedsServiceTest {
       status = SupportNeedStatus.IN_PROGRESS,
     )
     val auth = "auth"
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken(auth, "name") } returns "A User"
+    mockClaimFromJWTToken(token = auth, claimValue = "A User", claimName = "name")
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(
       PrisonerEntity(id = 1, nomsId = nomsId, creationDate = LocalDateTime.now(), prisonId = "MDI"),
@@ -989,8 +980,7 @@ class SupportNeedsServiceTest {
     val user = "User B"
     val fakeNow = LocalDateTime.parse("2025-02-01T12:00:00")
 
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns fakeNow
+    mockCurrentTime(fakeNow)
 
     whenever(prisonerRepository.findByNomsId(nomsId)).thenReturn(PrisonerEntity(id = 1, nomsId = nomsId, prisonId = "ABC"))
     whenever(prisonerSupportNeedRepository.findAllByPrisonerIdAndDeletedIsFalse(1)).thenReturn(
@@ -1085,8 +1075,6 @@ class SupportNeedsServiceTest {
         ),
       ),
     )
-
-    unmockkAll()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/api/ResettlementPassportDeliusApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/api/ResettlementPassportDeliusApiServiceTest.kt
@@ -15,7 +15,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.deliusapi.DeliusCreateAppointment
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.deliusapi.DeliusCreateAppointmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.integration.readFile
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.readFile
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external.ResettlementPassportDeliusApiService
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.jacksonCodecsConfigurer
 import java.time.Duration

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/CvlApiServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/external/CvlApiServiceTest.kt
@@ -1,8 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.external
 
+import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -30,7 +30,7 @@ class CvlApiServiceTest {
 
   @AfterEach
   fun reset() {
-    unmockkAll()
+    clearAllMocks()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV1ResettlementAssessmentAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV1ResettlementAssessmentAssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -32,7 +29,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
@@ -647,12 +643,8 @@ class AccommodationV1ResettlementAssessmentAssessmentStrategyTest : BaseResettle
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
     val pathway = Pathway.ACCOMMODATION
@@ -697,8 +689,6 @@ class AccommodationV1ResettlementAssessmentAssessmentStrategyTest : BaseResettle
         mapOf("reportType" to assessmentType.name, "pathway" to "ACCOMMODATION", "prisonId" to "MDI", "prisonerId" to "abc", "submittedBy" to "USER_1", "authSource" to "nomis"),
       )
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV2ResettlementAssessmentAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV2ResettlementAssessmentAssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -33,7 +30,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
@@ -1095,12 +1091,8 @@ class AccommodationV2ResettlementAssessmentAssessmentStrategyTest : BaseResettle
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
     val pathway = Pathway.ACCOMMODATION
@@ -1145,8 +1137,6 @@ class AccommodationV2ResettlementAssessmentAssessmentStrategyTest : BaseResettle
         mapOf("reportType" to assessmentType.name, "pathway" to "ACCOMMODATION", "prisonId" to "MDI", "prisonerId" to "abc", "submittedBy" to "USER_1", "authSource" to "nomis"),
       )
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV3ResettlementAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV3ResettlementAssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.assertj.core.groups.Tuple
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
@@ -37,7 +34,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 import org.assertj.core.api.Assertions as AssertJAssertions
@@ -323,12 +319,8 @@ class AccommodationV3ResettlementAssessmentStrategyTest : BaseResettlementAssess
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?, expectedProfileTagsEntity: ProfileTagsEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
     val pathway = Pathway.ACCOMMODATION
@@ -375,8 +367,6 @@ class AccommodationV3ResettlementAssessmentStrategyTest : BaseResettlementAssess
       Assertions.assertEquals(expectedException::class, actualException::class)
       Assertions.assertEquals(expectedException.message, actualException.message)
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV4ResettlementAssessmentAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/AccommodationV4ResettlementAssessmentAssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -31,7 +28,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
@@ -69,12 +65,8 @@ class AccommodationV4ResettlementAssessmentAssessmentStrategyTest : BaseResettle
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
     val pathway = Pathway.ACCOMMODATION
@@ -108,8 +100,6 @@ class AccommodationV4ResettlementAssessmentAssessmentStrategyTest : BaseResettle
       Assertions.assertEquals(expectedException::class, actualException::class)
       Assertions.assertEquals(expectedException.message, actualException.message)
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/BaseResettlementAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/BaseResettlementAssessmentStrategyTest.kt
@@ -25,6 +25,10 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettleme
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentRequestQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentResponsePage
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.data.resettlementassessment.ResettlementAssessmentStatus
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.CurrentDateTimeMockExtension.Companion.mockCurrentTime
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension
+import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.helpers.JWTTokenMockExtension.Companion.mockClaimFromJWTToken
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.PrisonerEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentEntity
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
@@ -38,7 +42,7 @@ import java.time.LocalDateTime
 import java.util.stream.Stream
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-@ExtendWith(MockitoExtension::class)
+@ExtendWith(MockitoExtension::class, CurrentDateTimeMockExtension::class, JWTTokenMockExtension::class)
 abstract class BaseResettlementAssessmentStrategyTest(val pathway: Pathway, val version: Int) {
   lateinit var resettlementAssessmentStrategy: ResettlementAssessmentStrategy
 
@@ -153,5 +157,15 @@ abstract class BaseResettlementAssessmentStrategyTest(val pathway: Pathway, val 
     val assessmentCaptor = argumentCaptor<ResettlementAssessmentEntity>()
     Mockito.verify(resettlementAssessmentRepository).save(assessmentCaptor.capture())
     Assertions.assertEquals(expectedEntity, assessmentCaptor.firstValue)
+  }
+
+  protected fun mockClaimFromJWTToken() {
+    mockClaimFromJWTToken(token = "string", claimValue = "System user", claimName = "name")
+    mockClaimFromJWTToken(token = "string", claimValue = "nomis", claimName = "auth_source")
+    mockClaimFromJWTToken(token = "string", claimValue = "USER_1", claimName = "sub")
+  }
+
+  protected fun mockCurrentTime() {
+    mockCurrentTime(testDate)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/ChildrenFamiliesAndCommunitiesV2AssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/ChildrenFamiliesAndCommunitiesV2AssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -31,7 +28,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
@@ -351,12 +347,8 @@ class ChildrenFamiliesAndCommunitiesV2AssessmentStrategyTest : BaseResettlementA
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
 
@@ -389,8 +381,6 @@ class ChildrenFamiliesAndCommunitiesV2AssessmentStrategyTest : BaseResettlementA
       Assertions.assertEquals(expectedException::class, actualException::class)
       Assertions.assertEquals(expectedException.message, actualException.message)
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/ValidationResettlementAssessmentStrategyTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/service/resettlementassessmentstrategies/ValidationResettlementAssessmentStrategyTest.kt
@@ -1,8 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.resettlementassessmentstrategies
 
-import io.mockk.every
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
@@ -31,7 +28,6 @@ import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.Rese
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentQuestionAndAnswerList
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentSimpleQuestionAndAnswer
 import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.jpa.entity.ResettlementAssessmentType
-import uk.gov.justice.digital.hmpps.hmppsresettlementpassportapi.service.getClaimFromJWTToken
 import java.time.LocalDateTime
 import java.util.stream.Stream
 
@@ -351,12 +347,8 @@ class ValidationResettlementAssessmentStrategyTest : BaseResettlementAssessmentS
   @ParameterizedTest
   @MethodSource("test complete assessment data")
   fun `test complete assessment`(assessmentType: ResettlementAssessmentType, assessment: ResettlementAssessmentCompleteRequest, expectedEntity: ResettlementAssessmentEntity?, expectedException: Throwable?, existingAssessment: ResettlementAssessmentEntity?) {
-    mockkStatic(::getClaimFromJWTToken)
-    every { getClaimFromJWTToken("string", "name") } returns "System user"
-    every { getClaimFromJWTToken("string", "auth_source") } returns "nomis"
-    every { getClaimFromJWTToken("string", "sub") } returns "USER_1"
-    mockkStatic(LocalDateTime::class)
-    every { LocalDateTime.now() } returns testDate
+    mockClaimFromJWTToken()
+    mockCurrentTime()
 
     val nomsId = "abc"
 
@@ -389,8 +381,6 @@ class ValidationResettlementAssessmentStrategyTest : BaseResettlementAssessmentS
       Assertions.assertEquals(expectedException::class, actualException::class)
       Assertions.assertEquals(expectedException.message, actualException.message)
     }
-
-    unmockkAll()
   }
 
   private fun `test complete assessment data`() = Stream.of(


### PR DESCRIPTION
- Extract static mocks to `MockExtensions.kt`
- Move static mocks to before-all and after-all
- Create testing objects lazily
- Move `OffenderEventsIntegrationTest` to inside `integration` test package
- Fix issue of unit tests waiting for container due to use of `readFile()` from `IntegrationTestBase`
- Add back missing mocks at `AppointmentsIntegrationTest`