### PR TITLE
ESWE-1819: Fix Case Notes API response

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/casenotesapi/CaseNotesDTO.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsresettlementpassportapi/data/casenotesapi/CaseNotesDTO.kt
@@ -21,9 +21,9 @@ data class CaseNote(
 )
 
 data class CaseNoteAmendment(
-  val caseNoteAmendmentId: Long,
-  val creationDateTime: LocalDateTime,
-  val authorUserName: String?,
+  val id: String?,
+  val creationDateTime: LocalDateTime?,
+  val authorUserName: String,
   val authorName: String,
   val authorUserId: String?,
   val additionalNoteText: String,


### PR DESCRIPTION
- replace `caseNoteAmendmentId` with `id`, make it optional
- revise as per Offender Case notes API spec