### PR TITLE
ESWE-1915: Unpin AppInsights agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,9 +29,7 @@ ADD --chown=appuser:appgroup https://truststore.pki.rds.amazonaws.com/global/glo
 
 WORKDIR /app
 COPY --from=builder --chown=appuser:appgroup /app/build/libs/hmpps-resettlement-passport-api*.jar /app/app.jar
-# Temp fix to use older version of appplication insights agent jar
-#COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
-ADD --chown=appuser:appgroup https://github.com/microsoft/ApplicationInsights-Java/releases/download/3.5.1/applicationinsights-agent-3.5.1.jar /app/agent.jar
+COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 COPY --from=builder --chown=appuser:appgroup /app/applicationinsights.json /app
 
 USER 2000


### PR DESCRIPTION
unpin "temp-fix" version `3.5.1` of AppInsights agent (`applicationinsights-agent-3.5.1.jar`) at Docker build