### PR TITLE
ESWE-2066: Remove CRN and Release date from SAR template prisoner sec…

### DIFF
--- a/src/main/resources/sar/template_hmpps-resettlement-passport-api.mustache
+++ b/src/main/resources/sar/template_hmpps-resettlement-passport-api.mustache
@@ -5,16 +5,12 @@
         <br/>
         <table class="data-table">
             <tr>
-                <td class="data-column-25">Case Reference Number</td>
                 <td class="data-column-25">Prison name</td>
                 <td class="data-column-25">Creation date</td>
-                <td class="data-column-25">Release date</td>
             </tr>
             <tr>
-                <td>{{ optionalValue crn }}</td>
                 <td>{{ getPrisonName prisonId }}</td>
                 <td>{{ optionalValue (formatDate creationDate) }}</td>
-                <td>{{ optionalValue (formatDate releaseDate) }}</td>
             </tr>
         </table>
     {{/prisoner}}

--- a/src/test/resources/sar/sar-generated-report.html
+++ b/src/test/resources/sar/sar-generated-report.html
@@ -228,16 +228,12 @@
 <br/>
 <table class="data-table">
   <tr>
-    <td class="data-column-25">Case Reference Number</td>
     <td class="data-column-25">Prison name</td>
     <td class="data-column-25">Creation date</td>
-    <td class="data-column-25">Release date</td>
   </tr>
   <tr>
     <td>No Data Held</td>
-    <td>No Data Held</td>
     <td>01 January 2024, 12:21:38 pm</td>
-    <td>No Data Held</td>
   </tr>
 </table>
 


### PR DESCRIPTION
**Template and report simplification:**

* Removed the "Case Reference Number" and "Release date" columns and their corresponding data from the prisoner information table in `template_hmpps-resettlement-passport-api.mustache`.
* Updated the generated SAR report HTML to match the template changes by removing the same columns and data.